### PR TITLE
Add pure jax baseline for mha kernels and remove runtime torch dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [linux-mi355-8]
 
     env:
       IMAGE: rocm/jax:rocm7.0.2-jax0.6.0-py3.12-ubu24
@@ -102,7 +102,7 @@ jobs:
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
               git ca-certificates curl build-essential pkg-config
-            python3 -m pip install --break-system-packages cmake ninja pyyaml pytest pytest-xdist
+            python3 -m pip install --break-system-packages cmake ninja pyyaml pytest pytest-xdist pytest-rerunfailures
             git --version
           '
 
@@ -276,15 +276,41 @@ jobs:
       - name: Run tests
         run: |
           docker exec "$CONTAINER_NAME" bash -lc '
-            pytest -n 8 --dist=loadscope --reruns 4 -q tests/test_mha_varlen_ja.py
-            python tests/multi_gpu_runner.py --save-failed failed_tests.txt
-            if [ -f failed_tests.txt ]; then
-              echo "Failed tests count: $(sort failed_tests.txt | uniq | wc -l)"
-              echo "Failed tests:"
-              sort failed_tests.txt | uniq
+            set -euxo pipefail
+
+            # Run MHA tests in parallel across GPUs and save failures
+            python tests/multi_gpu_runner.py tests/test_mha_ja.py --save-failed failed_mha.txt || true
+            if [ -s failed_mha.txt ]; then
+              echo "Failed MHA tests count: $(sort -u failed_mha.txt | wc -l)"
+              echo "Failed MHA tests:"
+              sort -u failed_mha.txt
+            else
+              echo "No MHA test failures"
             fi
+
+            # Run Varlen tests in parallel across GPUs and save failures
+            python tests/multi_gpu_runner.py tests/test_mha_varlen_ja.py --save-failed failed_varlen.txt || true
+            if [ -s failed_varlen.txt ]; then
+              echo "Failed Varlen tests count: $(sort -u failed_varlen.txt | wc -l)"
+              echo "Failed Varlen tests:"
+              sort -u failed_varlen.txt
+            else
+              echo "No Varlen test failures"
+            fi
+
+            # Combined failures for convenience
+            cat failed_mha.txt failed_varlen.txt 2>/dev/null | sort -u > failed_tests.txt || true
+            if [ -s failed_tests.txt ]; then
+              echo "Total failed tests: $(wc -l < failed_tests.txt)"
+              echo "All failed tests:"
+              cat failed_tests.txt
+            else
+              echo "No test failures across MHA and Varlen suites"
+            fi
+
+            # Optional benchmark
             python benchmarks/benchmark_mha.py
-          ' || echo "::warning::Pytest reported failures; continuing without failing the step"
+          ' || echo "::warning::Tests reported failures; continuing without failing the step"
 
       - name: Build summary
         if: always()

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -82,7 +82,7 @@ jobs:
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
               git ca-certificates curl build-essential pkg-config
-            python3 -m pip install --break-system-packages cmake ninja pyyaml pytest pytest-xdist
+            python3 -m pip install --break-system-packages cmake ninja pyyaml pytest pytest-xdist pytest-rerunfailures
             git --version
           '
 
@@ -202,15 +202,41 @@ jobs:
       - name: Run tests
         run: |
           docker exec "$CONTAINER_NAME" bash -lc '
-            pytest -n 8 --dist=loadscope --reruns 4 -q tests/test_mha_varlen_ja.py
-            python tests/multi_gpu_runner.py --save-failed failed_tests.txt
-            if [ -f failed_tests.txt ]; then
-              echo "Failed tests count: $(sort failed_tests.txt | uniq | wc -l)"
-              echo "Failed tests:"
-              sort failed_tests.txt | uniq
+            set -euxo pipefail
+
+            # Run MHA tests in parallel across GPUs and save failures
+            python tests/multi_gpu_runner.py tests/test_mha_ja.py --save-failed failed_mha.txt || true
+            if [ -s failed_mha.txt ]; then
+              echo "Failed MHA tests count: $(sort -u failed_mha.txt | wc -l)"
+              echo "Failed MHA tests:"
+              sort -u failed_mha.txt
+            else
+              echo "No MHA test failures"
             fi
+
+            # Run Varlen tests in parallel across GPUs and save failures
+            python tests/multi_gpu_runner.py tests/test_mha_varlen_ja.py --save-failed failed_varlen.txt || true
+            if [ -s failed_varlen.txt ]; then
+              echo "Failed Varlen tests count: $(sort -u failed_varlen.txt | wc -l)"
+              echo "Failed Varlen tests:"
+              sort -u failed_varlen.txt
+            else
+              echo "No Varlen test failures"
+            fi
+
+            # Combined failures for convenience
+            cat failed_mha.txt failed_varlen.txt 2>/dev/null | sort -u > failed_tests.txt || true
+            if [ -s failed_tests.txt ]; then
+              echo "Total failed tests: $(wc -l < failed_tests.txt)"
+              echo "All failed tests:"
+              cat failed_tests.txt
+            else
+              echo "No test failures across MHA and Varlen suites"
+            fi
+
+            # Optional benchmark
             python benchmarks/benchmark_mha.py
-          ' || echo "::warning::Pytest reported failures; continuing without failing the step"
+          ' || echo "::warning::Tests reported failures; continuing without failing the step"
 
       - name: Build summary
         if: always()

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export JA_ROOT_DIR="$PWD"                    # Set to the top of jax-aiter proje
 export AITER_SYMBOL_VISIBLE=1
 export GPU_ARCHS=gfx950                        # Example for MI350; use your GPU arch (e.g., gfx942 for MI300)
 # You may specify multiple archs as a semicolon-separated list, e.g.: GPU_ARCHS="gfx942;gfx950"
-export AITER_ASM_DIR="$JA_ROOT_DIR/third_party/aiter/hsa/gfx950"  # Example path matching our CI layout
+export AITER_ASM_DIR="$JA_ROOT_DIR/third_party/aiter/hsa/gfx950/"  # Example path matching our CI layout
 ```
 
 You can build natively or inside a ROCm container. You can pull docker images from the latest release of ROCm jax.

--- a/jax_aiter/baseline/bert_padding.py
+++ b/jax_aiter/baseline/bert_padding.py
@@ -1,62 +1,66 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
-"""
-JAX equivalents of AITer's bert_padding helpers used by tests:
-- unpad_input: flattens [B,S,...] to [N,...] using an attention mask (and optional unused mask),
-  also returns indices, cumulative sequence lengths, and max seqlen-in-batch.
-- pad_input: inverse operation that scatters back to [B,S,...] given indices.
-
-Accuracy-first implementation using jnp operations. Suitable for use outside or inside jit
-for now; later we can optimize with lax if needed for strict static-shape compilation.
-"""
-
-from __future__ import annotations
+# Adapted from https://github.com/mlcommons/training_results_v1.1/blob/main/NVIDIA/benchmarks/bert/implementations/pytorch/padding.py
 
 import jax.numpy as jnp
+from einops import rearrange, repeat
 
 
-def unpad_input(
-    hidden_states: jnp.ndarray,
-    attention_mask: jnp.ndarray,
-    unused_mask: jnp.ndarray | None = None,
-):
+def index_first_axis(input, indices):
+    """
+    JAX equivalent of torch IndexFirstAxis.forward
+    Select elements from input[indices] and flatten appropriately.
+    """
+    assert input.ndim >= 2
+    other_shape = input.shape[1:]
+    # JAX uses direct indexing, which is simpler than PyTorch's gather
+    # First flatten the trailing dimensions, then index, then reshape
+    input_flat = rearrange(input, "b ... -> b (...)")
+    gathered = input_flat[indices]
+    return gathered.reshape(-1, *other_shape)
+
+
+def index_put_first_axis(values, indices, first_axis_dim):
+    """
+    JAX equivalent of torch IndexPutFirstAxis.forward
+    Scatter values to output[indices].
+    """
+    assert indices.ndim == 1
+    assert values.ndim >= 2
+    output = jnp.zeros((first_axis_dim, *values.shape[1:]), dtype=values.dtype)
+    # JAX scatter via at[].set()
+    output = output.at[indices].set(values)
+    return output
+
+
+def unpad_input(hidden_states, attention_mask, unused_mask=None):
     """
     Arguments:
-        hidden_states: [batch, seqlen, ...]
-        attention_mask: [batch, seqlen], bool/int, 1 means valid, 0 means masked
-        unused_mask:   [batch, seqlen], bool/int, 1 means allocated-but-unused (optional)
-
-    Returns:
-        unpadded:                [total_nnz, ...]
-        indices:                 [total_nnz] (int32) indices into flattened [B*S]
-        cu_seqlens:              [batch + 1] (int32) cumulative sequence lengths
-        max_seqlen_in_batch:     scalar int32
-        used_seqlens_in_batch:   [batch] (int32) counts from attention_mask only
+        hidden_states: (batch, seqlen, ...)
+        attention_mask: (batch, seqlen), bool / int, 1 means valid and 0 means not valid.
+        unused_mask: (batch, seqlen), bool / int, 1 means the element is allocated but unused.
+    Return:
+        hidden_states: (total_nnz, ...), where total_nnz = number of tokens selected in attention_mask + unused_mask.
+        indices: (total_nnz), the indices of masked tokens from the flattened input sequence.
+        cu_seqlens: (batch + 1), the cumulative sequence lengths, used to index into hidden_states.
+        max_seqlen_in_batch: int
+        seqused: (batch), returns the number of tokens selected in attention_mask + unused_mask.
     """
-    assert hidden_states.ndim >= 2, "hidden_states must have [B,S,...]"
-
-    attention_mask_bool = attention_mask.astype(bool)
-    if unused_mask is not None:
-        all_masks = attention_mask_bool | unused_mask.astype(bool)
-    else:
-        all_masks = attention_mask_bool
-
-    seqlens_in_batch = all_masks.sum(axis=-1).astype(jnp.int32)
-    used_seqlens_in_batch = attention_mask_bool.sum(axis=-1).astype(jnp.int32)
-
-    flat_mask = all_masks.reshape(-1)
-    indices = jnp.nonzero(flat_mask, size=None)[0].astype(jnp.int32)
-
-    flat_states = hidden_states.reshape((-1,) + hidden_states.shape[2:])
-    unpadded = flat_states[indices]
-
-    cu = jnp.cumsum(seqlens_in_batch, dtype=jnp.int32)
-    cu_seqlens = jnp.pad(cu, (1, 0))
-
-    max_seqlen_in_batch = jnp.max(seqlens_in_batch).astype(jnp.int32)
-
+    all_masks = (
+        (attention_mask + unused_mask) if unused_mask is not None else attention_mask
+    )
+    seqlens_in_batch = all_masks.sum(axis=-1, dtype=jnp.int32)
+    used_seqlens_in_batch = attention_mask.sum(axis=-1, dtype=jnp.int32)
+    indices = jnp.nonzero(all_masks.flatten(), size=None)[0]
+    max_seqlen_in_batch = jnp.max(seqlens_in_batch).item()
+    cu_seqlens = jnp.pad(jnp.cumsum(seqlens_in_batch, axis=0, dtype=jnp.int32), (1, 0))
+    # TD [2022-03-04] We don't want to index with a bool mask, because Pytorch will expand the
+    # bool mask, then call nonzero to get the indices, then index with those. The indices is @dim
+    # times larger than it needs to be, wasting memory. It's faster and more memory-efficient to
+    # index with integer indices. Moreover, torch's index is a bit slower than it needs to be,
+    # so we write custom forward and backward to make it a bit faster.
     return (
-        unpadded,
+        index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices),
         indices,
         cu_seqlens,
         max_seqlen_in_batch,
@@ -64,24 +68,93 @@ def unpad_input(
     )
 
 
-def pad_input(
-    hidden_states: jnp.ndarray,
-    indices: jnp.ndarray,
-    batch: int,
-    seqlen: int,
-):
+def unpad_input_for_concatenated_sequences(hidden_states, attention_mask_in_length):
+    """
+    Supports concatenating short samples in one sequence. The attention_mask_in_length is utilized to mask other short samples. It helps efficient training of variant lengths-based samples (e.g., the supervised fine-tuning task in large language model).
+    The motivation for this function is explained [here](https://github.com/Dao-AILab/flash-attention/issues/432#issuecomment-1668822286).
+
+    For example, if batch = 3 and seqlen = 6, the attention_mask_in_length is:
+        ```
+        [
+          [2, 3, 0, 0, 0, 0],
+          [3, 2, 0, 0, 0, 0],
+          [6, 0, 0, 0, 0, 0]
+        ]
+        ```
+    , which refers to the 3D-attention mask:
+        ```
+        [
+          [
+            [1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0],
+            [0, 0, 1, 0, 0, 0],
+            [0, 0, 1, 1, 0, 0],
+            [0, 0, 1, 1, 1, 0],
+            [0, 0, 0, 0, 0, 1]
+          ],
+          [
+            [1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0, 0],
+            [0, 0, 0, 1, 0, 0],
+            [0, 0, 0, 1, 1, 0],
+            [0, 0, 0, 0, 0, 1]
+          ],
+          [
+            [1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0],
+            [1, 1, 1, 0, 0, 0],
+            [1, 1, 1, 1, 0, 0],
+            [1, 1, 1, 1, 1, 0],
+            [1, 1, 1, 1, 1, 1]
+          ]
+        ]
+        ```.
+
+    Arguments:
+        hidden_states: (batch, seqlen, ...)
+        attention_mask_in_length: (batch, seqlen), int, a nonzero number (e.g., 1, 2, 3, etc.) means length of concatenated sequence in b-th batch, and 0 means none.
+    Return:
+        hidden_states: (total_nnz, ...), where total_nnz = number of tokens in selected in attention_mask.
+        indices: (total_nnz), the indices of non-masked tokens from the flattened input sequence.
+        cu_seqlens: (batch + 1), the cumulative sequence lengths, used to index into hidden_states.
+        max_seqlen_in_batch: int
+    """
+    length = attention_mask_in_length.sum(axis=-1)
+    seqlen = attention_mask_in_length.shape[-1]
+    attention_mask_2d = jnp.arange(seqlen, dtype=length.dtype).reshape(
+        1, seqlen
+    ) < length.reshape(-1, 1)
+    real_indices_idx = jnp.nonzero(attention_mask_in_length.flatten(), size=None)[0]
+    seqlens_in_batch = attention_mask_in_length.flatten()[real_indices_idx]
+    indices = jnp.nonzero(attention_mask_2d.flatten(), size=None)[0]
+    max_seqlen_in_batch = jnp.max(seqlens_in_batch).item()
+    cu_seqlens = jnp.pad(jnp.cumsum(seqlens_in_batch, axis=0, dtype=jnp.int32), (1, 0))
+    # TD [2022-03-04] We don't want to index with a bool mask, because Pytorch will expand the
+    # bool mask, then call nonzero to get the indices, then index with those. The indices is @dim
+    # times larger than it needs to be, wasting memory. It's faster and more memory-efficient to
+    # index with integer indices. Moreover, torch's index is a bit slower than it needs to be,
+    # so we write custom forward and backward to make it a bit faster.
+    return (
+        index_first_axis(rearrange(hidden_states, "b s ... -> (b s) ..."), indices),
+        indices,
+        cu_seqlens,
+        max_seqlen_in_batch,
+    )
+
+
+def pad_input(hidden_states, indices, batch, seqlen):
     """
     Arguments:
-        hidden_states: [total_nnz, ...]
-        indices:       [total_nnz] (int32) positions in flattened [B*S]
-        batch:         int
-        seqlen:        int
-
-    Returns:
-        output: [batch, seqlen, ...]
+        hidden_states: (total_nnz, ...), where total_nnz = number of tokens in selected in attention_mask.
+        indices: (total_nnz), the indices that represent the non-masked tokens of the original padded input sequence.
+        batch: int, batch size for the padded sequence.
+        seqlen: int, maximum sequence length for the padded sequence.
+    Return:
+        hidden_states: (batch, seqlen, ...)
     """
-    flat_size = int(batch) * int(seqlen)
-    out_shape = (flat_size,) + hidden_states.shape[1:]
-    out = jnp.zeros(out_shape, dtype=hidden_states.dtype)
-    out = out.at[indices.astype(jnp.int32)].set(hidden_states)
-    return out.reshape((int(batch), int(seqlen)) + hidden_states.shape[1:])
+    dim = hidden_states.shape[-1]
+    # output = jnp.zeros((batch * seqlen), dim, dtype=hidden_states.dtype)
+    # output[indices] = hidden_states
+    output = index_put_first_axis(hidden_states, indices, batch * seqlen)
+    return rearrange(output, "(b s) ... -> b s ...", b=batch)

--- a/tests/test_mha_varlen_ja.py
+++ b/tests/test_mha_varlen_ja.py
@@ -1,44 +1,29 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
-
-import torch
-import aiter
-from aiter import dtypes
-from aiter.test_mha_common import (
-    attention_ref,
-    attn_bias_from_alibi_slopes,
-    ck_randval_to_dropout_mask,
-    convert_flash_attn_S_to_softmax,
-    generate_qkv,
-    generate_random_padding_mask,
-    pad_rearrange_dropout_mask_hts_to_bhss,
-)
 import pytest
 import argparse
 
 # JAX imports.
 import jax
 import jax.numpy as jnp
-from jax import dlpack as jax_dlpack
-from torch.utils import dlpack as torch_dlpack
 
 # JAX-aiter imports.
 import jax_aiter
-from jax_aiter.ja_compat import dtypes as jax_dtypes
+from jax_aiter.ja_compat import dtypes
 from jax_aiter.mha import flash_attn_varlen
+from jax_aiter.ja_compat.test_common import benchmark, run_perftest
+from jax_aiter.baseline.mha_attn import (
+    attention_ref,
+    generate_qkv,
+    ck_randval_to_dropout_mask,
+    convert_flash_attn_S_to_softmax,
+    attn_bias_from_alibi_slopes,
+    generate_random_padding_mask,
+    pad_rearrange_dropout_mask_hts_to_bhss,
+)
 
 
-def _to_jax(t: torch.Tensor) -> jnp.ndarray:
-    """Convert PyTorch tensor to JAX array."""
-    return jax_dlpack.from_dlpack(t.detach())
-
-
-def _to_torch(x: jnp.ndarray) -> torch.Tensor:
-    """Convert JAX array to PyTorch tensor."""
-    return torch_dlpack.from_dlpack(x)
-
-
-def run_torch(
+def run_jax(
     q,
     k,
     v,
@@ -54,8 +39,8 @@ def run_torch(
     upcast=True,
     reorder_ops=False,
 ):
-    (b, seqlen_q, _, _) = q.shape
-    (_, seqlen_k, _, _) = k.shape
+    b, seqlen_q, _, _ = q.shape
+    _, seqlen_k, _, _ = k.shape
 
     if bias is not None:
         attn_bias = bias.reshape(b, 1, seqlen_q, seqlen_k)
@@ -64,9 +49,10 @@ def run_torch(
             alibi_slopes,
             seqlen_q,
             seqlen_k,
-            query_padding_mask,
-            key_padding_mask,
+            query_padding_mask=query_padding_mask,
+            key_padding_mask=key_padding_mask,
             causal=causal,
+            key_leftpad=None,
         )
     else:
         attn_bias = None
@@ -75,25 +61,46 @@ def run_torch(
         q,
         k,
         v,
-        query_padding_mask,
-        key_padding_mask,
-        attn_bias,
-        dropout_p,
-        dropout_mask,
+        query_padding_mask=query_padding_mask,
+        key_padding_mask=key_padding_mask,
+        attn_bias=attn_bias,
+        dropout_p=dropout_p,
+        dropout_mask=dropout_mask,
         causal=causal,
         window_size=window_size,
         upcast=upcast,
         reorder_ops=reorder_ops,
+        key_leftpad=None,
     )
 
     if dout == None:
         return out
-    else:
-        dq, dk, dv = torch.autograd.grad(out, (q, k, v), dout)
-        return out, dq, dk, dv
+
+    def f(q_, k_, v_):
+        o_, _, _ = attention_ref(
+            q_,
+            k_,
+            v_,
+            query_padding_mask=query_padding_mask,
+            key_padding_mask=key_padding_mask,
+            attn_bias=attn_bias,
+            dropout_p=dropout_p,
+            dropout_mask=dropout_mask,
+            causal=causal,
+            window_size=window_size,
+            upcast=upcast,
+            reorder_ops=reorder_ops,
+            key_leftpad=None,
+        )
+        return o_
+
+    _, vjp_fn = jax.vjp(f, q, k, v)
+    dq, dk, dv = vjp_fn(dout)
+
+    return out, dq, dk, dv
 
 
-def run_jax(
+def run_jax_aiter(
     q,
     k,
     v,
@@ -109,132 +116,152 @@ def run_jax(
     deterministic=False,
     return_lse=True,
     return_attn_probs=False,
+    cu_seqlens_q_padded=None,
+    cu_seqlens_k_padded=None,
+    input_layout="BSHD",
 ):
-    """JAX implementation for varlen attention."""
-    # Unpad inputs using generate_qkv.
-    (
-        q_unpad,
-        k_unpad,
-        v_unpad,
-        cu_seqlens_q,
-        cu_seqlens_k,
-        max_seqlen_q,
-        max_seqlen_k,
-        q_padded,
-        k_padded,
-        v_padded,
-        output_pad_fn,
-        dq_pad_fn,
-        dk_pad_fn,
-    ) = generate_qkv(q, k, v, query_padding_mask, key_padding_mask, kvpacked=False)
+    window_size = tuple(int(x) for x in window_size)
+
+    B, max_seqlen_q, nheads_q, d_q = q.shape
+    _, max_seqlen_k, _, d_v = v.shape
+
+    # lengths and cu_seqlens from masks
+    seqlens_q = jnp.sum(query_padding_mask, axis=1).astype(dtypes.i32)
+    seqlens_k = jnp.sum(key_padding_mask, axis=1).astype(dtypes.i32)
+
+    if min_seqlen_q is not None:
+        assert bool(jnp.all(seqlens_q >= min_seqlen_q))
+
+    cu_seqlens_q = jnp.concatenate(
+        [jnp.array([0], dtype=dtypes.i32), jnp.cumsum(seqlens_q)], axis=0
+    )
+    cu_seqlens_k = jnp.concatenate(
+        [jnp.array([0], dtype=dtypes.i32), jnp.cumsum(seqlens_k)], axis=0
+    )
+
+    # unpad q, k, v
+    q_chunks, k_chunks, v_chunks = [], [], []
+    for b in range(B):
+        q_len = int(seqlens_q[b])
+        k_len = int(seqlens_k[b])
+        q_chunks.append(q[b, :q_len, :, :])
+        k_chunks.append(k[b, :k_len, :, :])
+        v_chunks.append(v[b, :k_len, :, :])
+
+    q_unpad = jnp.concatenate(q_chunks, axis=0)  # (total_q, nheads_q, d_q)
+    k_unpad = jnp.concatenate(k_chunks, axis=0)  # (total_k, nheads_q, d_q)
+    v_unpad = jnp.concatenate(v_chunks, axis=0)  # (total_k, nheads_q, d_v)
+
+    # bias: forward-only (tests skip varlen bwd for bias)
     if bias is not None:
-        # TODO - implement generate_bias() to unpad.
-        total_q = q_unpad.shape[0]
-        assert total_q == batch_size * max_seqlen_q
-        assert q.shape[1] == max_seqlen_q
-        assert k.shape[1] == max_seqlen_k
-        bias_unpad = bias.reshape(batch_size * max_seqlen_q, max_seqlen_k)
+        bias_chunks = []
+        for b in range(B):
+            q_len = int(seqlens_q[b])
+            bias_chunks.append(bias[b, :q_len, :max_seqlen_k])
+        bias_unpad = jnp.concatenate(bias_chunks, axis=0)  # (total_q, max_seqlen_k)
     else:
         bias_unpad = None
 
-    # Convert to JAX
-    qj = _to_jax(q_unpad)
-    kj = _to_jax(k_unpad)
-    vj = _to_jax(v_unpad)
-    cu_seqlens_qj = _to_jax(cu_seqlens_q)
-    cu_seqlens_kj = _to_jax(cu_seqlens_k)
-    bj = _to_jax(bias_unpad) if bias_unpad is not None else None
-    alj = _to_jax(alibi_slopes) if alibi_slopes is not None else None
-
-    window_size = tuple(int(x) for x in window_size)
-
-    # JAX forward wrapper.
-    def fwd_core(Q, K, V, B):
+    def _fwd(Q_unpad, K_unpad, V_unpad):
         return flash_attn_varlen(
-            Q,
-            K,
-            V,
-            cu_seqlens_qj,
-            cu_seqlens_kj,
-            max_seqlen_q,
-            max_seqlen_k,
+            Q_unpad,
+            K_unpad,
+            V_unpad,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            int(max_seqlen_q),
+            int(max_seqlen_k),
             min_seqlen_q=min_seqlen_q,
             dropout_p=dropout_p,
             softmax_scale=None,
             logits_soft_cap=0.0,
             causal=causal,
             window_size=window_size,
-            bias=B,
-            alibi_slopes=alj,
-            block_table=None,
+            bias=bias_unpad,
+            alibi_slopes=alibi_slopes,
             deterministic=deterministic,
             return_lse=return_lse,
             return_attn_probs=return_attn_probs,
+            block_table=None,
+            out=None,
+            cu_seqlens_q_padded=cu_seqlens_q_padded,
+            cu_seqlens_k_padded=cu_seqlens_k_padded,
         )
 
-    # One forward + vjp.
-    (outj, lse_j, S_dmask_jax), pullback = jax.vjp(
-        lambda Q, K, V, B: fwd_core(Q, K, V, B), qj, kj, vj, bj
+    (out_unpad, softmax_lse, S_dmask), pullback = jax.vjp(
+        _fwd, q_unpad, k_unpad, v_unpad
     )
 
-    # Convert and pad output.
-    out_t = output_pad_fn(_to_torch(outj))
+    # pad output back to [B, max_seqlen_q, nheads_q, d_v]
+    out = jnp.zeros((B, max_seqlen_q, nheads_q, d_v), dtype=out_unpad.dtype)
+    start_q = 0
+    for b in range(B):
+        q_len = int(seqlens_q[b])
+        out = out.at[b, :q_len, :, :].set(out_unpad[start_q : start_q + q_len])
+        start_q += q_len
 
-    # Convert dropout mask if present
+    # dropout mask reconstruction
     dropout_mask = None
-    if dropout_p > 0.0 and return_attn_probs:
-        (_, seqlen_q, _, d) = q.shape
-        (_, seqlen_k, _, d) = k.shape
-        S_dmask = _to_torch(S_dmask_jax)
-        S_dmask = ck_randval_to_dropout_mask(S_dmask, dropout_p)
-        S_dmask = pad_rearrange_dropout_mask_hts_to_bhss(
-            S_dmask, cu_seqlens_q, seqlen_q, seqlen_k
+    if dropout_p > 0.0 and return_attn_probs and S_dmask is not None:
+        S_thresh = ck_randval_to_dropout_mask(S_dmask, dropout_p)
+        S_bhss = pad_rearrange_dropout_mask_hts_to_bhss(
+            S_thresh,
+            cu_seqlens_q,
+            seqlen_q_rounded=max_seqlen_q,
+            seqlen_k_rounded=max_seqlen_k,
         )
-        S_dmask_converted = convert_flash_attn_S_to_softmax(
-            S_dmask,
-            seqlen_q,
-            seqlen_k,
-            query_padding_mask,
-            key_padding_mask,
-            d,
-            True,  # dropout_p > 0.0
+        S_conv = convert_flash_attn_S_to_softmax(
+            S_bhss,
+            max_seqlen_q,
+            max_seqlen_k,
+            query_padding_mask=query_padding_mask,
+            key_padding_mask=key_padding_mask,
+            head_dim=d_q,
+            is_dropout=True,
             causal=causal,
             window_size=window_size,
         )
-        dropout_mask = S_dmask_converted >= 0
+        dropout_mask = S_conv >= 0
 
-    # Handle gradients if dout provided.
-    if dout is None or not return_lse:
-        return out_t, dropout_mask, None, None, None
+    if dout is None:
+        return out, dropout_mask, None, None, None
 
-    # Unpad dout for JAX
-    from aiter.bert_padding import unpad_input
+    # unpad dout
+    dout_chunks = []
+    for b in range(B):
+        q_len = int(seqlens_q[b])
+        dout_chunks.append(dout[b, :q_len, :, :])
+    dout_unpad = jnp.concatenate(dout_chunks, axis=0)
 
-    dout_unpad, _, _, _, _ = unpad_input(dout, query_padding_mask)
-    cot = (
-        _to_jax(dout_unpad),
-        jnp.zeros_like(lse_j) if return_lse else None,
-        jnp.zeros_like(S_dmask_jax) if return_attn_probs else None,
-    )
+    # flash_attn_varlen always returns 3 outputs → 3 cotangents
+    ct_lse = jnp.zeros_like(softmax_lse) if softmax_lse is not None else None
+    ct_S = jnp.zeros_like(S_dmask) if S_dmask is not None else None
+    cot = (dout_unpad, ct_lse, ct_S)
 
-    # Pullback.
-    if bj is None:
-        dqj, dkj, dvj, _ = pullback(cot)
-    else:
-        dqj, dkj, dvj, dbj = pullback(cot)
+    dq_unpad, dk_unpad, dv_unpad = pullback(cot)
 
-    # Convert grads back to torch and pad
-    dq_t = _to_torch(dqj)
-    dk_t = _to_torch(dkj)
-    dv_t = _to_torch(dvj)
+    # pad grads back
+    dq = jnp.zeros_like(q)
+    dk = jnp.zeros_like(k)
+    dv = jnp.zeros_like(v)
 
-    dq = dq_pad_fn(dq_t)
-    dk = dk_pad_fn(dk_t)
-    dv = dk_pad_fn(dv_t)  # Note: CK test used dk_pad_fn for dv as well
+    start_q = 0
+    start_k = 0
+    for b in range(B):
+        q_len = int(seqlens_q[b])
+        k_len = int(seqlens_k[b])
 
-    return out_t, dropout_mask, dq, dk, dv
+        dq = dq.at[b, :q_len, :, :].set(dq_unpad[start_q : start_q + q_len])
+        dk = dk.at[b, :k_len, :, :].set(dk_unpad[start_k : start_k + k_len])
+        dv = dv.at[b, :k_len, :, :].set(dv_unpad[start_k : start_k + k_len])
+
+        start_q += q_len
+        start_k += k_len
+
+    return out, dropout_mask, dq, dk, dv
 
 
+@pytest.mark.parametrize("input_layout", ["BSHD", "KVPACKED"])
 @pytest.mark.parametrize("dtype", [dtypes.fp16, dtypes.bf16])
 @pytest.mark.parametrize("mha_type", ["mha", "mqa", "gqa"])
 @pytest.mark.parametrize("deterministic", [True, False])
@@ -292,75 +319,84 @@ def test_flash_attn_varlen_func(
     deterministic,
     mha_type,
     dtype,
+    input_layout,
 ):
     return_lse = True
-    torch.random.manual_seed(0)
-    torch.cuda.empty_cache()
+    key = jax.random.PRNGKey(0)
+    dtype = dtypes.to_jax_dtype(dtype)
     nheads_k = nheads if mha_type == "mha" else (1 if mha_type == "mqa" else 3)
     assert nheads % nheads_k == 0
-    window_size = (-1, -1) if not local else tuple(torch.randint(0, seqlen_k, (2,)))
 
-    q = torch.randn(
-        batch_size, seqlen_q, nheads, d, device="cuda", dtype=dtype, requires_grad=True
-    )
-    k = torch.randn(
-        batch_size,
-        seqlen_k,
-        nheads_k,
-        d,
-        device="cuda",
+    # window
+    if not local:
+        window_size = (-1, -1)
+    else:
+        key, sub = jax.random.split(key)
+        # torch.randint(0, seqlen_k, (2,))
+        window_size = tuple(
+            jax.random.randint(sub, (2,), 0, seqlen_k, dtype=jnp.int32).tolist()
+        )
+
+    key, sub = jax.random.split(key)
+    q = jax.random.normal(
+        sub,
+        (batch_size, seqlen_q, nheads, d),
         dtype=dtype,
-        requires_grad=True,
     )
-    v = torch.randn(
-        batch_size,
-        seqlen_k,
-        nheads_k,
-        d_v,
-        device="cuda",
+    key, sub = jax.random.split(key)
+    k = jax.random.normal(
+        sub,
+        (batch_size, seqlen_k, nheads_k, d),
         dtype=dtype,
-        requires_grad=True,
+    )
+    key, sub = jax.random.split(key)
+    v = jax.random.normal(
+        sub,
+        (batch_size, seqlen_k, nheads_k, d_v),
+        dtype=dtype,
     )
 
     if bias_type == "bias":
         # TODO - We need to implement unpad bias [batch_size, seqlen_q, seqlen_k] -> [total_q, max_seqlen_k]
         # Let total_q = batch_size * seqlen_q to pass the test for now
         query_padding_mask = generate_random_padding_mask(
-            seqlen_q, batch_size, "cuda", mode="full"
+            seqlen_q, batch_size, key, mode="full"
         )
         key_padding_mask = generate_random_padding_mask(
-            seqlen_k, batch_size, "cuda", mode="full"
+            seqlen_k, batch_size, key, mode="full"
         )
     else:
         query_padding_mask = generate_random_padding_mask(
-            seqlen_q, batch_size, "cuda", mode="random"
+            seqlen_q, batch_size, key, mode="random"
         )
         key_padding_mask = generate_random_padding_mask(
-            seqlen_k, batch_size, "cuda", mode="random"
+            seqlen_k, batch_size, key, mode="random"
         )
 
     attn_bias = None
     alibi_slopes = None
     if bias_type == "bias":
-        attn_bias = torch.randn(
-            batch_size,
-            seqlen_q,
-            seqlen_k,
-            device="cuda",
+        key, sub = jax.random.split(key)
+        attn_bias = jax.random.normal(
+            sub,
+            (batch_size, seqlen_q, seqlen_k),
             dtype=dtype,
-            requires_grad=True,
         )
     elif bias_type == "alibi":
-        alibi_slopes = torch.rand(batch_size, nheads, device="cuda", dtype=dtypes.fp32)
+        key, sub = jax.random.split(key)
+        alibi_slopes = jax.random.uniform(
+            sub,
+            (batch_size, nheads),
+            minval=0.0,
+            maxval=1.0,
+            dtype=dtypes.to_jax_dtype(dtypes.fp32),
+        )
 
-    dout = torch.randn(
-        batch_size,
-        seqlen_q,
-        nheads,
-        d_v,
-        device="cuda",
+    key, sub = jax.random.split(key)
+    dout = jax.random.normal(
+        sub,
+        (batch_size, seqlen_q, nheads, d_v),
         dtype=dtype,
-        requires_grad=True,
     )
 
     # return_attn_probs is just for host verification (to produce same dropout mask)
@@ -372,7 +408,7 @@ def test_flash_attn_varlen_func(
 
     # Returns from the aiter:
     # out_aiter, dropout_mask_aiter, dq_aiter, dk_aiter, dv_aiter
-    jax_result = run_jax(
+    jax_result = run_jax_aiter(
         q,
         k,
         v,
@@ -388,12 +424,19 @@ def test_flash_attn_varlen_func(
         deterministic,
         return_lse,
         return_attn_probs,
+        cu_seqlens_q_padded=None,
+        cu_seqlens_k_padded=None,
+        input_layout=input_layout,
     )
 
     out_jax, dropout_mask_jax, dq_jax, dk_jax, dv_jax = jax_result
 
+    # Helper for max |.| like .abs().max().item() in torch
+    def max_abs(x):
+        return float(jnp.max(jnp.abs(x)))
+
     # Run torch reference
-    out_ref, dq_ref, dk_ref, dv_ref = run_torch(
+    out_ref, dq_ref, dk_ref, dv_ref = run_jax(
         q,
         k,
         v,
@@ -408,7 +451,7 @@ def test_flash_attn_varlen_func(
         window_size,
     )
 
-    out_pt, dq_pt, dk_pt, dv_pt = run_torch(
+    out_pt, dq_pt, dk_pt, dv_pt = run_jax(
         q,
         k,
         v,
@@ -426,17 +469,17 @@ def test_flash_attn_varlen_func(
     )
 
     # Compare outputs
-    # print(f"AITER vs REF Output max diff: {(out_aiter - out_ref).abs().max().item()}")
-    print(f"JAX vs REF Output max diff: {(out_jax - out_ref).abs().max().item()}")
-    # print(f"JAX vs AITER Output max diff: {(out_jax - out_aiter).abs().max().item()}")
-    print(f"PT vs REF Output max diff: {(out_pt - out_ref).abs().max().item()}")
+    out_diff = max_abs(out_jax - out_ref)
+    ref_diff = max_abs(out_pt - out_ref)
+    print(f"JAX vs REF Output max diff: {out_diff}")
+    print(f"PT vs REF Output max diff: {ref_diff}")
 
     # (Ruturaj4): Note: Forward output assertion commented out to match third_party test behavior.
     # The CK kernels can have larger deviations in BF16 + dropout + local cases.
-    # out_tol = max(4 * (out_pt - out_ref).abs().max().item(), 0.01)
-    # assert (
-    #     out_jax - out_ref
-    # ).abs().max().item() <= out_tol, "JAX output doesn't match REF"
+    out_tol = max(4 * ref_diff, 0.01)
+    assert (
+        out_diff <= out_tol
+    ), f"JAX output doesn't match REF: diff {out_diff} > tol {out_tol}"
 
     # TODO: Support varlen bwd for bias
     if bias_type == "bias":
@@ -446,29 +489,23 @@ def test_flash_attn_varlen_func(
         # print(f"AITER dQ max diff: {(dq_aiter - dq_ref).abs().max().item()}")
         # print(f"AITER dK max diff: {(dk_aiter - dk_ref).abs().max().item()}")
         # print(f"AITER dV max diff: {(dv_aiter - dv_ref).abs().max().item()}")
-        print(f"JAX dQ max diff: {(dq_jax - dq_ref).abs().max().item()}")
-        print(f"JAX dK max diff: {(dk_jax - dk_ref).abs().max().item()}")
-        print(f"JAX dV max diff: {(dv_jax - dv_ref).abs().max().item()}")
+        print(f"JAX dQ max diff: {max_abs(dq_jax - dq_ref)}")
+        print(f"JAX dK max diff: {max_abs(dk_jax - dk_ref)}")
+        print(f"JAX dV max diff: {max_abs(dv_jax - dv_ref)}")
         # print(f"JAX vs AITER dQ max diff: {(dq_jax - dq_aiter).abs().max().item()}")
         # print(f"JAX vs AITER dK max diff: {(dk_jax - dk_aiter).abs().max().item()}")
         # print(f"JAX vs AITER dV max diff: {(dv_jax - dv_aiter).abs().max().item()}")
-        print(f"PT dQ max diff: {(dq_pt - dq_ref).abs().max().item()}")
-        print(f"PT dK max diff: {(dk_pt - dk_ref).abs().max().item()}")
-        print(f"PT dV max diff: {(dv_pt - dv_ref).abs().max().item()}")
+        print(f"PT dQ max diff: {max_abs(dq_pt - dq_ref)}")
+        print(f"PT dK max diff: {max_abs(dk_pt - dk_ref)}")
+        print(f"PT dV max diff: {max_abs(dv_pt - dv_ref)}")
 
-        dq_tol = max(10 * (dq_pt - dq_ref).abs().max().item(), 0.01)
-        dk_tol = max(10 * (dk_pt - dk_ref).abs().max().item(), 0.01)
-        dv_tol = max(10 * (dv_pt - dv_ref).abs().max().item(), 0.01)
+        dq_tol = max(10 * max_abs(dq_pt - dq_ref), 0.01)
+        dk_tol = max(10 * max_abs(dk_pt - dk_ref), 0.01)
+        dv_tol = max(10 * max_abs(dv_pt - dv_ref), 0.01)
 
-        assert (
-            dq_jax - dq_ref
-        ).abs().max().item() <= dq_tol, "JAX dQ doesn't match REF"
-        assert (
-            dk_jax - dk_ref
-        ).abs().max().item() <= dk_tol, "JAX dK doesn't match REF"
-        assert (
-            dv_jax - dv_ref
-        ).abs().max().item() <= dv_tol, "JAX dV doesn't match REF"
+        assert max_abs(dq_jax - dq_ref) <= dq_tol, "JAX dQ doesn't match REF"
+        assert max_abs(dk_jax - dk_ref) <= dk_tol, "JAX dK doesn't match REF"
+        assert max_abs(dv_jax - dv_ref) <= dv_tol, "JAX dV doesn't match REF"
 
 
 if __name__ == "__main__":
@@ -580,6 +617,15 @@ if __name__ == "__main__":
         help="""Data type. Default is 'bf16'.
     e.g.: -dt bf16""",
     )
+    parser.add_argument(
+        "-i",
+        "--input_layout",
+        type=str,
+        choices=["BSHD", "KVPACKED"],
+        default="BSHD",
+        help="""input_layout.
+        e.g.: -i BSHD""",
+    )
 
     args = parser.parse_args()
     dtype = dtypes.d_dtypes[args.dtype]
@@ -600,4 +646,5 @@ if __name__ == "__main__":
         args.deterministic,
         args.mha_type,
         dtype,
+        args.input_layout,
     )


### PR DESCRIPTION
## Motivation

This PR add pure jax baseline for variable length MHA kernels. This also helps us remove torch dependency from the MHA tests.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

I have removed torch dependencies from the mha tests and updated the per PR CI and nightly.

## Test Result

<!-- Briefly summarize test outcomes. -->

Currently after checking locally all the variable length MHA tests pass and following is the summary of non-variable length MHA test results:

```
Total tests expected: 155520

GPU 0: 19408 passed, 32 failed, 0 skipped, 194 reruns
GPU 1: 19405 passed, 35 failed, 0 skipped, 188 reruns
GPU 2: 19408 passed, 32 failed, 0 skipped, 169 reruns
GPU 3: 19399 passed, 41 failed, 0 skipped, 176 reruns
GPU 4: 19405 passed, 35 failed, 0 skipped, 177 reruns
GPU 5: 19408 passed, 32 failed, 0 skipped, 163 reruns
GPU 6: 19415 passed, 25 failed, 0 skipped, 157 reruns
GPU 7: 19398 passed, 42 failed, 0 skipped, 205 reruns

--------------------------------------------------------------------------------
TOTAL: 155246 passed, 274 failed, 0 skipped, 1429 reruns
Total tests completed: 155520
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
