### PR TITLE
Add reproducible MXFP4 publication workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,8 +91,10 @@ hlo_dumps/
 # CI perf run outputs (ephemeral; produced by ci/perf/run_8b_fp4.sh).
 ci_perf_out/
 # Ignore local doc artifacts (runs/, perf/, logs/, ...) but keep committed
-# release notes trackable (a file can't be re-included if its parent dir is
-# excluded, so ignore docs/* contents rather than the docs/ dir itself).
+# release notes and public recipes trackable (a file can't be re-included if
+# its parent dir is excluded, so ignore docs/* contents rather than docs/).
 docs/*
 !docs/RELEASE_NOTES_v0.1.0-alpha.md
+!docs/recipes/
+!docs/recipes/*.md
 .rocprofv3/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ JAX-AITER integrates AMD's [AITER](https://github.com/ROCm/aiter) operator libra
 
 Python 3.12 required. ROCm 7.2+.
 
+For the single-node Llama 3.1 8B MaxText reproduction recipe—MXFP4, TE FP8
+current scaling, BF16, and MLPerf Training 6.0 convergence logging—see
+[`docs/recipes/mxfp4_llama3_8b_maxtext.md`](docs/recipes/mxfp4_llama3_8b_maxtext.md).
+The tracked runners support CPU-only recipe resolution before any GPU run.
+
 ## What is AITER?
 
 **AITER** (AI Tensor Engine for ROCm) is AMD's centralized library of AI operators optimized for ROCm GPUs (MI300, MI350). It provides hand-tuned CK (Composable Kernel) and ASM kernels for attention, normalization, activations, GEMM, and more.
@@ -77,8 +82,8 @@ Two wheel variants are published:
 
 | Variant | Size | Contents | Use when |
 |---------|------|----------|----------|
-| **lite** (`+lite`) | ~43 MiB | MXFP4/FP4 GEMM, BF16 GEMM, MXFP4 cast, RMSNorm, SiLU-and-Mul. **No flash attention (MHA).** | MXFP4 (FP4) training path; the canonical FP4 recipe routes attention through TransformerEngine, so MHA is not needed. |
-| **full** | ~513 MiB | Everything above **plus** AITER flash attention (`flash_attn_func` / `flash_attn_varlen`). | You need AITER MHA. |
+| **lite** (`+lite`) | ~43 MiB | MXFP4/FP4 GEMM, BF16 GEMM, MXFP4 cast, RMSNorm, SiLU-and-Mul. **No flash attention (MHA).** | MXFP4 training with attention routed through TransformerEngine. |
+| **full** | ~513 MiB | Everything above **plus** AITER flash attention (`flash_attn_func` / `flash_attn_varlen`). | You need AITER MHA, including the direct-MHA publication recipe linked above. |
 
 ```bash
 # Lite (MXFP4 path):

--- a/csrc/ffi/cast_mxfp4/cast_transpose_mxfp4_kernel_shuffled.cu
+++ b/csrc/ffi/cast_mxfp4/cast_transpose_mxfp4_kernel_shuffled.cu
@@ -450,14 +450,12 @@ __device__ __forceinline__ uint32_t deterministic_sr_word(
 __device__ __forceinline__ uint16_t cvt_f32x4_to_fp4x4_sr(
     float v0, float v1, float v2, float v3,
     float scale,
-    const uint32_t* __restrict__ key,
-    uint32_t role,
+    uint32_t stream,
     uint32_t direction,
     uint32_t row,
     uint32_t col
 ) {
 #if defined(__gfx950__)
-    uint32_t stream = deterministic_sr_stream(key, role, direction);
     uint32_t rng0 = deterministic_sr_word(
         stream, row, col);
     uint32_t rng1 = deterministic_sr_word(
@@ -644,6 +642,20 @@ void cast_transpose_mxfp4_shuffled(
     const int K_packed = N / 2;
     const int M_packed = M / 2;
 
+    // The explicit key, semantic role and direction are invariant across all
+    // eight 32x32 chunks. Compute each active direction stream once here rather
+    // than repeating the key load/mix in every unrolled chunk body.
+    uint32_t row_sr_stream = 0;
+    uint32_t col_sr_stream = 0;
+    if constexpr (USE_SR_ROW) {
+        row_sr_stream = deterministic_sr_stream(
+            sr_key, (uint32_t)sr_role, 0u);
+    }
+    if constexpr (USE_SR_COL) {
+        col_sr_stream = deterministic_sr_stream(
+            sr_key, (uint32_t)sr_role, 1u);
+    }
+
     // ========================================================================
     // Shared Memory - 32x32 BF16 Tile with Padding
     // ========================================================================
@@ -806,8 +818,7 @@ void cast_transpose_mxfp4_shuffled(
                     uint16_t fp4x4;
                     if constexpr (USE_SR_ROW) {
                         fp4x4 = cvt_f32x4_to_fp4x4_sr(
-                            v0, v1, v2, v3, native_scale, sr_key,
-                            (uint32_t)sr_role, 0u,
+                            v0, v1, v2, v3, native_scale, row_sr_stream, 0u,
                             (uint32_t)global_row, (uint32_t)global_col_base);
                     } else {
                         fp4x4 = cvt_f32x4_to_fp4x4(v0, v1, v2, v3, native_scale);
@@ -897,8 +908,7 @@ void cast_transpose_mxfp4_shuffled(
                     uint16_t fp4x4;
                     if constexpr (USE_SR_COL) {
                         fp4x4 = cvt_f32x4_to_fp4x4_sr(
-                            v0, v1, v2, v3, native_scale, sr_key,
-                            (uint32_t)sr_role, 1u,
+                            v0, v1, v2, v3, native_scale, col_sr_stream, 1u,
                             (uint32_t)global_row_base, (uint32_t)global_col);
                     } else {
                         fp4x4 = cvt_f32x4_to_fp4x4(v0, v1, v2, v3, native_scale);

--- a/docs/recipes/mxfp4_llama3_8b_maxtext.md
+++ b/docs/recipes/mxfp4_llama3_8b_maxtext.md
@@ -1,0 +1,230 @@
+# Reproduce Llama 3.1 8B MXFP4 training on ROCm
+
+This recipe compares **MXFP4**, **TE FP8 current scaling**, and **BF16** on one
+8 × AMD Instinct MI355X (`gfx950`) node. Each command launches one explicit
+leg; there is no precision loop. JAX-AITER has no PyTorch runtime dependency.
+
+## Reproduction status and versions
+
+The recipe controls are fixed, but release provenance still needs to be sealed:
+
+- Official image: `rocm/jax-training:<TODO_VERIFY exact tag>` and
+  `sha256:<TODO_VERIFY digest>`.
+- ROCm, JAX, `jaxlib`, ROCm PJRT/plugin, TransformerEngine, and AITER versions:
+  `TODO_VERIFY` from the selected image and built JAX-AITER tree.
+- JAX-AITER release tag/commit containing this recipe: `TODO_VERIFY`.
+  Development base was `perf/mxfp4-deterministic-sr @ 06d7adf`.
+- ROCm/MaxText branch: `aiter-fp4-integration`; record the checked-out commit as
+  `TODO_VERIFY` before publishing results.
+- Dataset and tokenizer checksums: `TODO_VERIFY`.
+
+Do not publish throughput from a run until these values and the resolved recipe
+banner in each `train.log` have been recorded.
+
+## Start the official ROCm JAX container
+
+Use AMD's official `rocm/jax-training` image because this comparison needs the
+JAX ROCm backend and a compatible JAX TransformerEngine build. Resolve and pin
+the exact tag and digest above before running:
+
+```bash
+export ROCM_JAX_IMAGE='rocm/jax-training:<TODO_VERIFY exact tag>@sha256:<TODO_VERIFY digest>'
+docker pull "$ROCM_JAX_IMAGE"
+docker run --rm -it \
+  --network=host \
+  --device=/dev/kfd --device=/dev/dri \
+  --ipc=host --shm-size=64G --group-add video \
+  --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+  -v "$PWD":/workspace -w /workspace \
+  "$ROCM_JAX_IMAGE" bash
+```
+
+The commands below assume the host workspace is mounted at `/workspace`.
+The runners retain the project default `/ruvaidya/aiter_proj`; setting
+`PROJECT_ROOT=/workspace` resolves all paths for this mount.
+
+## Clone, build, and install
+
+Clone both source trees on the host before starting the container, or inside
+the mounted workspace:
+
+```bash
+cd /workspace
+git clone --recursive https://github.com/ROCm/jax-aiter.git
+git clone --branch aiter-fp4-integration https://github.com/ROCm/maxtext.git
+git -C jax-aiter rev-parse HEAD
+git -C maxtext rev-parse HEAD
+```
+
+Build the full JAX-AITER source distribution because MXFP4 uses direct
+JAX-AITER MHA in this recipe:
+
+```bash
+export PROJECT_ROOT=/workspace
+export JAX_AITER_ROOT="$PROJECT_ROOT/jax-aiter"
+export MAXTEXT_ROOT="$PROJECT_ROOT/maxtext"
+export JA_ROOT_DIR="$JAX_AITER_ROOT"
+export AITER_SYMBOL_VISIBLE=1
+export GPU_ARCHS=gfx950
+export AITER_ASM_DIR="$JAX_AITER_ROOT/third_party/aiter/hsa/"
+
+cd "$JAX_AITER_ROOT"
+test -d third_party/pytorch/build_static/install/include \
+  || bash scripts/build_static_pytorch.sh
+make
+python3 jax_aiter/jit/build_jit.py
+make ja_mods
+python3 -m pip install .
+
+cd "$MAXTEXT_ROOT"
+python3 -m pip install --no-deps -e .
+python3 -m pip install 'mlperf-logging==4.1.58'
+```
+
+The static PyTorch tree supplies build-time headers only. Do not install,
+import, or route execution through PyTorch at runtime. The selected official
+image must already provide MaxText's compatible JAX/ROCm and TE dependencies;
+`--no-deps` prevents an editable MaxText install from replacing that stack.
+
+Record the environment before a run:
+
+```bash
+python3 - <<'PY'
+import importlib.metadata as m
+for name in ("jax", "jaxlib", "jax-rocm7-pjrt", "jax-rocm7-plugin",
+             "transformer-engine", "jax-aiter", "maxtext", "mlperf-logging"):
+    try:
+        print(f"{name}=={m.version(name)}")
+    except m.PackageNotFoundError:
+        print(f"{name}=NOT_INSTALLED")
+PY
+```
+
+## Dataset prerequisites
+
+The convergence runner defaults to the MLPerf Megatron-format C4 data:
+
+```text
+/workspace/datasets/mlperf_c4/c4-train.en_6_text_document.bin
+/workspace/datasets/mlperf_c4/c4-train.en_6_text_document.idx
+/workspace/datasets/mlperf_c4/c4-validation-91205-samples.en_text_document.bin
+/workspace/datasets/mlperf_c4/c4-validation-91205-samples.en_text_document.idx
+```
+
+Obtain and preprocess C4 under its applicable license and the MLPerf Training
+6.0 Llama 3.1 8B data procedure. This repository does not redistribute the
+dataset. The tokenizer defaults to MaxText's
+`src/maxtext/assets/tokenizers/tokenizer_llama3.tiktoken`. Verify every data and
+tokenizer checksum against the finalized publication manifest (`TODO_VERIFY`).
+
+The runner also supports `DATASET_TYPE=grain` with
+`DATA_ROOT/c4_en_parquet/{train,val}/*.parquet` and
+`DATA_ROOT/llama31_tokenizer`, but that is a separately labeled data route.
+
+## Resolve recipes without a GPU run
+
+`RECIPE_DRY_RUN=1` prints the banner and every MaxText argument without
+importing JAX or launching training:
+
+```bash
+cd "$JAX_AITER_ROOT"
+RECIPE_DRY_RUN=1 PROJECT_ROOT=/workspace \
+  bash scripts/recipes/run_nvfp4_match_8b.sh mxfp4 /workspace/results/dry-run 50
+bash tests/test_publication_perf_runner.sh
+```
+
+Check that the banner says batch 4, global batch 32, sequence 8192, seed 0,
+`.97`, FSDP8, Shardy, `scan_layers=False`, fp32 weight/mu state, iota false,
+autotune 5, and the expected quantization and attention backend.
+
+## Run the three 50-step performance legs
+
+Each command is one foreground process. Run them sequentially, with no
+profiler. Do not combine modes in a shell loop. The runner creates an atomic
+`.launch_once` marker and refuses to reuse a leg directory; choose a fresh
+`PERF_ROOT` for every new attempt.
+
+```bash
+cd "$JAX_AITER_ROOT"
+export PROJECT_ROOT=/workspace
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export PERF_ROOT=/workspace/results/llama3_8b_perf_50
+
+bash scripts/recipes/run_nvfp4_match_8b.sh mxfp4 "$PERF_ROOT" 50
+bash scripts/recipes/run_nvfp4_match_8b.sh te_fp8_currentscaling "$PERF_ROOT" 50
+bash scripts/recipes/run_nvfp4_match_8b.sh bf16 "$PERF_ROOT" 50
+```
+
+The authoritative modes are:
+
+- MXFP4: `quantization=aiter_fp4`, direct `attention=aiter_flash`.
+- TE FP8 current scaling:
+  `quantization=te_fp8_currentscaling`, `attention=cudnn_flash_te`.
+- BF16: empty quantization, `attention=cudnn_flash_te`.
+
+Parse the last ten completed steps. In a complete 50-step process these are
+steps 40–49:
+
+```bash
+python3 ci/perf/parse_perf_log.py \
+  --log "$PERF_ROOT/mxfp4/train.log" --tail-n 10 --label mxfp4 \
+  --out-json "$PERF_ROOT/mxfp4/tail_40_49.json"
+```
+
+Repeat the parser command for `te_fp8_currentscaling` and `bf16`. Confirm
+`tail_first_step=40` and `tail_last_step=49`; do not report a partial window.
+
+## Run MXFP4 convergence
+
+The canonical command uses Megatron C4, a 6,000-step horizon, eval every 384
+steps for 32 eval steps, target loss 3.3, seed 0, and MLPerf logging:
+
+```bash
+cd "$JAX_AITER_ROOT"
+export PROJECT_ROOT=/workspace
+export DATA_ROOT=/workspace/datasets
+export XLA_PYTHON_CLIENT_MEM_FRACTION=.97
+export TTC_ROOT=/workspace/results/llama3_8b_mxfp4_ttc
+
+bash scripts/recipes/run_mlperf_ttc_8b.sh \
+  mxfp4_ttc mxfp4 "$TTC_ROOT" 6000
+```
+
+The convergence runner uses the same atomic one-launch guard. Keep a failed or
+interrupted directory as evidence and choose a new `TTC_ROOT` for any retry.
+
+The same runner accepts `te_fp8_currentscaling` and `bf16` as explicit
+single-leg modes when matched convergence baselines are required.
+
+## Outputs and MLPerf checks
+
+Expected files:
+
+- Performance: `$PERF_ROOT/<mode>/train.log` plus MaxText outputs below that
+  leg directory.
+- Convergence: `$TTC_ROOT/mxfp4_ttc/train.log`,
+  `$TTC_ROOT/mxfp4_ttc/mlperf.log`, and MaxText outputs.
+- Every `train.log` begins with `RESOLVED_RECIPE_BEGIN` /
+  `RESOLVED_RECIPE_END` and records the full command and XLA flags.
+
+Run the Training 6.0 compliance checker from a temporary directory because it
+writes `compliance_checker.log` in its current working directory:
+
+```bash
+CHECK_DIR="$(mktemp -d)"
+( cd "$CHECK_DIR" && \
+  python3 -m mlperf_logging.compliance_checker \
+    --usage training --ruleset 6.0.0 --werror \
+    "$TTC_ROOT/mxfp4_ttc/mlperf.log" )
+```
+
+A single successful compliance check is not MLPerf RCP validation. RCP requires
+the official multi-run protocol and `rcp_checker` over the complete result set;
+do not present this one-run convergence recipe as an RCP score.
+
+## Memory and failure policy
+
+`.97` is the only canonical memory fraction. If any leg reports OOM,
+`RESOURCE_EXHAUSTED`, or an out-of-memory error at `.97`, stop and preserve the
+command, banner, and log. Do not lower the fraction, reduce the batch, retry in
+the same output directory, or quote a fallback run as canonical.

--- a/docs/recipes/mxfp4_llama3_8b_maxtext.md
+++ b/docs/recipes/mxfp4_llama3_8b_maxtext.md
@@ -137,6 +137,13 @@ Check that the banner says batch 4, global batch 32, sequence 8192, seed 0,
 `.97`, FSDP8, Shardy, `scan_layers=False`, fp32 weight/mu state, iota false,
 autotune 5, and the expected quantization and attention backend.
 
+Set `MODEL_CONTROLS=llama31_mlperf` to align a synthetic performance process
+with the Llama 3.1 convergence model controls (`rope_use_scale=False`, MLPerf
+attention scaling, embedding-logit normalization off, and Megatron
+initialization). The historical `MODEL_NAME=llama3-8b` route uses a different
+rotary-embedding implementation and must be reported as a separate operating
+point.
+
 ## Run the three 50-step performance legs
 
 Each command is one foreground process. Run them sequentially, with no

--- a/scripts/recipes/run_mlperf_ttc_8b.sh
+++ b/scripts/recipes/run_mlperf_ttc_8b.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# Single-leg Llama 3.1 8B convergence/MLPerf-logging runner.
+#
+# Usage:
+#   bash scripts/recipes/run_mlperf_ttc_8b.sh \
+#     TAG mxfp4|te_fp8_currentscaling|bf16 OUT_ROOT [STEPS]
+#
+# Defaults reproduce the 6,000-step MLPerf-directional recipe. PROJECT_ROOT,
+# JAX_AITER_ROOT, MAXTEXT_ROOT, DATA_ROOT, and individual dataset paths are
+# optional mount overrides. RECIPE_DRY_RUN=1 performs CPU-only resolution.
+set -euo pipefail
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
+is_true() { [[ "${1,,}" == "1" || "${1,,}" == "true" || "${1,,}" == "yes" ]]; }
+
+[[ $# -ge 3 && $# -le 4 ]] || die "usage: $0 TAG MODE OUT_ROOT [STEPS]"
+TAG="$1"
+MODE="$2"
+OUT_ROOT="$3"
+STEPS="${4:-6000}"
+
+PROJECT_ROOT="${PROJECT_ROOT:-/ruvaidya/aiter_proj}"
+JAX_AITER_ROOT="${JAX_AITER_ROOT:-${PROJECT_ROOT}/jax-aiter}"
+MAXTEXT_ROOT="${MAXTEXT_ROOT:-${PROJECT_ROOT}/maxtext}"
+DATA_ROOT="${DATA_ROOT:-${PROJECT_ROOT}/datasets}"
+MAXTEXT_CONFIG="${MAXTEXT_CONFIG:-src/maxtext/configs/base.yml}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+MEMFRAC="${XLA_PYTHON_CLIENT_MEM_FRACTION:-.97}"
+[[ "$MEMFRAC" == ".97" ]] || die "canonical mem fraction is .97; stop instead of lowering it"
+
+MODEL_NAME="${MODEL_NAME:-llama3.1-8b}"
+FSDP="${ICI_FSDP_PARALLELISM:-8}"
+SHARDY="${SHARDY:-True}"
+SCAN_LAYERS="${SCAN_LAYERS:-False}"
+PER_DEVICE_BATCH="${PER_DEVICE_BATCH:-4}"
+GRAD_ACCUM="${GRAD_ACCUM:-1}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-32}"
+MAX_TARGET_LENGTH="${MAX_TARGET_LENGTH:-8192}"
+AUTOTUNE_LEVEL="${AUTOTUNE_LEVEL:-5}"
+COMBINE_TH_BYTES="${COMBINE_TH_BYTES:-67108864}"
+ENABLE_NNX="${ENABLE_NNX:-False}"
+USE_IOTA_EMBED="${USE_IOTA_EMBED:-False}"
+WEIGHT_DTYPE="${WEIGHT_DTYPE:-float32}"
+MU_DTYPE="${MU_DTYPE:-float32}"
+INIT_WEIGHTS_SEED="${INIT_WEIGHTS_SEED:-0}"
+
+case "$MODE" in
+  mxfp4)
+    LABEL="MXFP4"; QUANTIZATION="aiter_fp4"; MLPERF_PRECISION=mxfp4; USE_AITER=True
+    SR_KEY_MODE=maxtext_runtime_params_rng
+    ATTENTION="${ATTENTION:-aiter_flash}"
+    REMAT_POLICY="${REMAT_POLICY:-minimal_flash_save_fp4col}"
+    ;;
+  te_fp8_currentscaling)
+    LABEL="TE FP8 current scaling"; QUANTIZATION="te_fp8_currentscaling"; MLPERF_PRECISION=fp8; USE_AITER=False
+    SR_KEY_MODE=n/a
+    ATTENTION="${ATTENTION:-cudnn_flash_te}"
+    REMAT_POLICY="${REMAT_POLICY:-minimal_flash}"
+    ;;
+  bf16)
+    LABEL="BF16"; QUANTIZATION=""; MLPERF_PRECISION=bfloat16; USE_AITER=False
+    SR_KEY_MODE=n/a
+    ATTENTION="${ATTENTION:-cudnn_flash_te}"
+    REMAT_POLICY="${REMAT_POLICY:-minimal_flash}"
+    ;;
+  *) die "bad mode '$MODE' (expected mxfp4, te_fp8_currentscaling, or bf16)" ;;
+esac
+
+export XLA_PYTHON_CLIENT_MEM_FRACTION="$MEMFRAC"
+export JAX_PLATFORMS=rocm
+export HIP_VISIBLE_DEVICES="${HIP_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
+export HIP_FORCE_DEV_KERNARG=1 HSA_FORCE_FINE_GRAIN_PCIE=1
+export ROCPROFILER_QUEUE_INTERPOSITION=0 ROCPROFILER_REGISTER_ENABLED=0
+export HSA_NO_SCRATCH_RECLAIM=1 GPU_MAX_HW_QUEUES=2
+export RCCL_WARP_SPEED_AUTO=0 NCCL_DEBUG="${NCCL_DEBUG:-VERSION}"
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1 NVTE_USE_HIPBLASLT=1
+export NVTE_FUSED_ATTN=1 NVTE_FUSED_ATTN_CK=1 NVTE_FUSED_ATTN_AOTRITON=0
+export NVTE_CK_USES_FWD_V3=1 NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=1 NVTE_CK_HOW_V3_BF16_CVT=2
+export DECOUPLE_GCLOUD=TRUE PYTHONUNBUFFERED=1
+export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
+export JA_ROOT_DIR="${JA_ROOT_DIR:-$JAX_AITER_ROOT}"
+export AITER_ASM_DIR="${AITER_ASM_DIR:-${JAX_AITER_ROOT}/third_party/aiter/hsa/}"
+export AITER_SYMBOL_VISIBLE=1 GPU_ARCHS="${GPU_ARCHS:-gfx950}"
+export PYTHONPATH="${MAXTEXT_ROOT}/src:${JAX_AITER_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+if [[ "$MODE" == "mxfp4" ]]; then
+  export FP4_SELECT="${FP4_SELECT:-dispatch}" AITER_FP4_ATTN=1
+  case "$FP4_SELECT" in
+    dispatch) export AITER_FP4_DISPATCH=1; unset AITER_FORCE_KERNEL_NAME AITER_FORCE_LOG2_K_SPLIT ;;
+    forced)
+      unset AITER_FP4_DISPATCH
+      export AITER_FORCE_KERNEL_NAME=_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E
+      export AITER_FORCE_LOG2_K_SPLIT=0
+      ;;
+    heuristic) unset AITER_FP4_DISPATCH AITER_FORCE_KERNEL_NAME AITER_FORCE_LOG2_K_SPLIT ;;
+    *) die "bad FP4_SELECT '$FP4_SELECT' (expected dispatch, forced, or heuristic)" ;;
+  esac
+  export JA_FP4_HADAMARD_PASSES="${JA_FP4_HADAMARD_PASSES:-wgrad}"
+  export JA_FP4_SR_PASSES="${JA_FP4_SR_PASSES:-wgrad_col}"
+  export JA_FP4_DGRAD_PARTITION="${JA_FP4_DGRAD_PARTITION:-gather_packed}"
+  export JA_FP4_DGRAD_REUSE_FWD_COL="${JA_FP4_DGRAD_REUSE_FWD_COL:-1}"
+  export JA_FP4_REMAT_SAVE_COL="${JA_FP4_REMAT_SAVE_COL:-both}"
+  export JA_FP4_PACK_GATEUP_AG="${JA_FP4_PACK_GATEUP_AG:-1}"
+  export JA_MHA_BWD_ATOMIC_FP32=0 JA_MHA_BWD_BF16_CVT=2
+  export JA_MHA_FUSE_GQA_REDUCE=1 JA_MHA_ZERO_PAD=1
+  unset AITER_FP4_SR AITER_FUSED_QUANT_HADAMARD AITER_FP4_HADAMARD_OFF
+else
+  unset FP4_SELECT AITER_FP4_DISPATCH AITER_FP4_ATTN
+  unset JA_FP4_HADAMARD_PASSES JA_FP4_SR_PASSES JA_FP4_DGRAD_PARTITION
+  unset JA_FP4_DGRAD_REUSE_FWD_COL JA_FP4_REMAT_SAVE_COL JA_FP4_PACK_GATEUP_AG
+  unset JA_MHA_BWD_ATOMIC_FP32 JA_MHA_BWD_BF16_CVT JA_MHA_FUSE_GQA_REDUCE JA_MHA_ZERO_PAD
+fi
+
+MODE_ARGS=()
+if [[ "$USE_AITER" == "True" && "$ATTENTION" != "aiter_flash" ]]; then
+  MODE_ARGS+=(aiter_attention=False)
+elif [[ "$USE_AITER" != "True" && "$ATTENTION" == "aiter_flash" ]]; then
+  MODE_ARGS+=(aiter_gemm=False)
+fi
+
+XLA_BASE="--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_triton_gemm=false --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=${AUTOTUNE_LEVEL}"
+XLA_SCHED="--xla_gpu_all_reduce_combine_threshold_bytes=${COMBINE_TH_BYTES} --xla_gpu_all_gather_combine_threshold_bytes=${COMBINE_TH_BYTES} --xla_gpu_reduce_scatter_combine_threshold_bytes=${COMBINE_TH_BYTES} --xla_gpu_enable_pipelined_all_gather=true --xla_gpu_enable_pipelined_reduce_scatter=true --xla_gpu_enable_pipelined_all_reduce=true --xla_gpu_enable_while_loop_double_buffering=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_disable_hlo_passes=rematerialization"
+XLA_SCAN_FALSE="--xla_gpu_enable_command_buffer= --xla_gpu_experimental_enable_fusion_autotuner=false --xla_gpu_enable_allocator_spatial_partitioning=false"
+export XLA_FLAGS="${XLA_BASE} ${XLA_SCHED} ${XLA_SCAN_FALSE}${EXTRA_XLA:+ ${EXTRA_XLA}}"
+
+DATASET_TYPE="${DATASET_TYPE:-megatron}"
+NUM_EPOCH="${NUM_EPOCH:-1}"
+case "$DATASET_TYPE" in
+  megatron)
+    MEGATRON_TRAIN_BIN="${MEGATRON_TRAIN_BIN:-${DATA_ROOT}/mlperf_c4/c4-train.en_6_text_document.bin}"
+    MEGATRON_EVAL_BIN="${MEGATRON_EVAL_BIN:-${DATA_ROOT}/mlperf_c4/c4-validation-91205-samples.en_text_document.bin}"
+    TOKENIZER_PATH="${TOKENIZER_PATH:-${MAXTEXT_ROOT}/src/maxtext/assets/tokenizers/tokenizer_llama3.tiktoken}"
+    DATA_ARGS=(packing=False max_segments_per_seq=1 dataset_type=megatron
+      "grain_train_files=${MEGATRON_TRAIN_BIN}" "grain_eval_files=${MEGATRON_EVAL_BIN}"
+      vocab_size=128256 "tokenizer_path=${TOKENIZER_PATH}" tokenizer_type=tiktoken
+      enable_data_shuffling=True data_shuffle_seed=0 "num_epoch=${NUM_EPOCH}")
+    ;;
+  grain)
+    PARQUET_DIR="${PARQUET_DIR:-${DATA_ROOT}/c4_en_parquet}"
+    GRAIN_TRAIN_FILES="${GRAIN_TRAIN_FILES:-${PARQUET_DIR}/train/*.parquet}"
+    GRAIN_EVAL_FILES="${GRAIN_EVAL_FILES:-${PARQUET_DIR}/val/*.parquet}"
+    TOKENIZER_PATH="${TOKENIZER_PATH:-${DATA_ROOT}/llama31_tokenizer}"
+    DATA_ARGS=(packing=True max_segments_per_seq=32 dataset_type=grain grain_file_type=parquet
+      grain_packing_type=first_fit tokenize_train_data=true tokenize_eval_data=true
+      "grain_train_files=${GRAIN_TRAIN_FILES}" "grain_eval_files=${GRAIN_EVAL_FILES}"
+      "grain_worker_count=${GRAIN_WORKER_COUNT:-8}" "grain_worker_count_eval=${GRAIN_WORKER_COUNT_EVAL:-2}"
+      "grain_num_threads=${GRAIN_NUM_THREADS:-16}" "grain_num_threads_eval=${GRAIN_NUM_THREADS_EVAL:-16}"
+      "tokenizer_path=${TOKENIZER_PATH}" tokenizer_type=huggingface
+      enable_data_shuffling=True data_shuffle_seed=0 "num_epoch=${NUM_EPOCH}")
+    ;;
+  *) die "bad DATASET_TYPE '$DATASET_TYPE' (expected megatron or grain)" ;;
+esac
+
+LEARNING_RATE="${LEARNING_RATE:-8.0e-4}"
+LR_SCHEDULE_STEPS="${LR_SCHEDULE_STEPS:-1200000}"
+WARMUP_FRACTION="${WARMUP_FRACTION:-1.0666666666666667e-4}"
+LR_FINAL_FRACTION="${LR_FINAL_FRACTION:-0.1}"
+EVAL_INTERVAL="${EVAL_INTERVAL:-384}"
+EVAL_STEPS="${EVAL_STEPS:-32}"
+TARGET_EVAL_LOSS="${TARGET_EVAL_LOSS:-3.3}"
+OUTDIR="${OUT_ROOT}/${TAG}"
+LOGFILE="${OUTDIR}/train.log"
+MLPERF_LOG="${OUTDIR}/mlperf.log"
+
+CMD=(stdbuf -oL -eL "$PYTHON_BIN" -m maxtext.trainers.pre_train.train "$MAXTEXT_CONFIG"
+  hardware=gpu "model_name=${MODEL_NAME}" "attention=${ATTENTION}"
+  "ici_fsdp_parallelism=${FSDP}" ici_data_parallelism=1 ici_expert_parallelism=1
+  "remat_policy=${REMAT_POLICY}" "scan_layers=${SCAN_LAYERS}" "use_iota_embed=${USE_IOTA_EMBED}"
+  logits_dot_in_fp32=False dtype=bfloat16 "weight_dtype=${WEIGHT_DTYPE}" "mu_dtype=${MU_DTYPE}"
+  "per_device_batch_size=${PER_DEVICE_BATCH}" "gradient_accumulation_steps=${GRAD_ACCUM}"
+  "global_batch_size_to_train_on=${GLOBAL_BATCH_SIZE}" "init_weights_seed=${INIT_WEIGHTS_SEED}"
+  "max_target_length=${MAX_TARGET_LENGTH}" "shardy=${SHARDY}" "${DATA_ARGS[@]}"
+  lr_schedule_type=cosine "learning_rate=${LEARNING_RATE}" "learning_rate_schedule_steps=${LR_SCHEDULE_STEPS}"
+  "warmup_steps_fraction=${WARMUP_FRACTION}" "learning_rate_final_fraction=${LR_FINAL_FRACTION}"
+  adam_b1=0.9 adam_b2=0.95 adam_eps=1.0e-5 adam_weight_decay=0.1 gradient_clipping_threshold=1.0
+  dropout_rate=0.0 "eval_interval=${EVAL_INTERVAL}" "eval_steps=${EVAL_STEPS}"
+  "target_eval_loss=${TARGET_EVAL_LOSS}" enable_checkpointing=False
+  "steps=${STEPS}" "use_jax_aiter=${USE_AITER}" "run_name=${TAG}" "quantization=${QUANTIZATION}" "${MODE_ARGS[@]}"
+  "enable_nnx=${ENABLE_NNX}" "pure_nnx=${ENABLE_NNX}" "pure_nnx_decoder=${ENABLE_NNX}"
+  query_pre_attn_scalar=0.08838834764831843 rope_use_scale=False normalize_embedding_logits=False
+  megatron_init_std=0.02 megatron_residual_scale=True num_vocab_tiling=1
+  enable_mlperf_logging=True "mlperf_log_path=${MLPERF_LOG}"
+  "mlperf_submission_org=${MLPERF_SUBMISSION_ORG:-jax-aiter}"
+  "mlperf_submission_platform=${MLPERF_SUBMISSION_PLATFORM:-MI355X_8xGPU_1node}"
+  mlperf_submission_division=closed mlperf_submission_benchmark=llama31_8b
+  "mlperf_lowest_precision_linear=${MLPERF_PRECISION}" "base_output_directory=${OUTDIR}")
+
+print_recipe() {
+  printf '%s\n' "=== RESOLVED_RECIPE_BEGIN ==="
+  printf 'runner=convergence tag=%s mode=%s label=%s processes=1 steps=%s\n' "$TAG" "$MODE" "$LABEL" "$STEPS"
+  printf 'quantization=%s attention=%s use_jax_aiter=%s scan_layers=%s remat_policy=%s\n' "${QUANTIZATION:-none}" "$ATTENTION" "$USE_AITER" "$SCAN_LAYERS" "$REMAT_POLICY"
+  printf 'autotune=%s weight_dtype=%s mu_dtype=%s use_iota_embed=%s batch=%s global_batch=%s sequence=%s init_seed=%s mem_fraction=%s\n' "$AUTOTUNE_LEVEL" "$WEIGHT_DTYPE" "$MU_DTYPE" "$USE_IOTA_EMBED" "$PER_DEVICE_BATCH" "$GLOBAL_BATCH_SIZE" "$MAX_TARGET_LENGTH" "$INIT_WEIGHTS_SEED" "$MEMFRAC"
+  printf 'fsdp=%s shardy=%s scheduler=nvidia combine_threshold=%s dataset_type=%s grad_accum=%s\n' "$FSDP" "$SHARDY" "$COMBINE_TH_BYTES" "$DATASET_TYPE" "$GRAD_ACCUM"
+  printf 'learning_rate=%s lr_schedule_steps=%s warmup_fraction=%s eval_interval=%s eval_steps=%s target_eval_loss=%s\n' "$LEARNING_RATE" "$LR_SCHEDULE_STEPS" "$WARMUP_FRACTION" "$EVAL_INTERVAL" "$EVAL_STEPS" "$TARGET_EVAL_LOSS"
+  printf 'hadamard_passes=%s sr_passes=%s dgrad_partition=%s dgrad_reuse_fwd_col=%s remat_save_col=%s pack_gateup_ag=%s\n' "${JA_FP4_HADAMARD_PASSES:-n/a}" "${JA_FP4_SR_PASSES:-n/a}" "${JA_FP4_DGRAD_PARTITION:-n/a}" "${JA_FP4_DGRAD_REUSE_FWD_COL:-n/a}" "${JA_FP4_REMAT_SAVE_COL:-n/a}" "${JA_FP4_PACK_GATEUP_AG:-n/a}"
+  printf 'fp4_select=%s fp4_attention_gemm=%s sr_key_mode=%s mha_fuse_gqa_reduce=%s mha_zero_pad=%s\n' "${FP4_SELECT:-n/a}" "${AITER_FP4_ATTN:-n/a}" "$SR_KEY_MODE" "${JA_MHA_FUSE_GQA_REDUCE:-n/a}" "${JA_MHA_ZERO_PAD:-n/a}"
+  printf 'te_atomic_fp32=%s te_bf16_cvt=%s ja_mha_atomic_fp32=%s ja_mha_bf16_cvt=%s mlperf_precision=%s\n' "$NVTE_CK_IS_V3_ATOMIC_FP32" "$NVTE_CK_HOW_V3_BF16_CVT" "${JA_MHA_BWD_ATOMIC_FP32:-n/a}" "${JA_MHA_BWD_BF16_CVT:-n/a}" "$MLPERF_PRECISION"
+  printf 'rocm_safeguards=jax_platforms:%s,queue_interposition:%s,register_enabled:%s,no_scratch_reclaim:%s,dev_kernarg:%s,fine_grain_pcie:%s\n' "$JAX_PLATFORMS" "$ROCPROFILER_QUEUE_INTERPOSITION" "$ROCPROFILER_REGISTER_ENABLED" "$HSA_NO_SCRATCH_RECLAIM" "$HIP_FORCE_DEV_KERNARG" "$HSA_FORCE_FINE_GRAIN_PCIE"
+  printf 'project_root=%s jax_aiter_root=%s maxtext_root=%s data_root=%s oom_policy=stop_and_report_no_memfrac_fallback\n' "$PROJECT_ROOT" "$JAX_AITER_ROOT" "$MAXTEXT_ROOT" "$DATA_ROOT"
+  printf '%s\n' "=== RESOLVED_RECIPE_END ==="
+}
+
+if is_true "${RECIPE_DRY_RUN:-0}"; then
+  print_recipe
+  printf 'XLA_FLAGS=%s\n' "$XLA_FLAGS"
+  printf 'RESOLVED_ARG=%s\n' "${CMD[@]}"
+  exit 0
+fi
+
+[[ -d "$MAXTEXT_ROOT" ]] || die "MAXTEXT_ROOT does not exist: $MAXTEXT_ROOT"
+mkdir -p "$OUTDIR"
+[[ ! -e "$LOGFILE" ]] || die "train.log already exists; use a fresh output root: $LOGFILE"
+LAUNCH_MARKER="${OUTDIR}/.launch_once"
+if ! (set -o noclobber; printf '%s tag=%s mode=%s pid=%s\n' "$(date -u)" "$TAG" "$MODE" "$$" >"$LAUNCH_MARKER") 2>/dev/null; then
+  die "launch already attempted for $OUTDIR; use a fresh output root"
+fi
+{ print_recipe; printf 'XLA_FLAGS=%s\n' "$XLA_FLAGS"; printf 'COMMAND='; printf ' %q' "${CMD[@]}"; printf '\n'; } | tee "$LOGFILE"
+start_ts="$(date +%s)"
+set +e
+(cd "$MAXTEXT_ROOT" && "${CMD[@]}") 2>&1 | tee -a "$LOGFILE"
+rc=${PIPESTATUS[0]}
+set -e
+printf '=== %s EXIT %s wall=%ss %s ===\n' "$TAG" "$rc" "$(( $(date +%s) - start_ts ))" "$(date -u)" | tee -a "$LOGFILE"
+exit "$rc"

--- a/scripts/recipes/run_nvfp4_match_8b.sh
+++ b/scripts/recipes/run_nvfp4_match_8b.sh
@@ -29,6 +29,7 @@ MEMFRAC="${XLA_PYTHON_CLIENT_MEM_FRACTION:-.97}"
 [[ "$MEMFRAC" == ".97" ]] || die "canonical mem fraction is .97; stop instead of lowering it"
 
 MODEL_NAME="${MODEL_NAME:-llama3.1-8b}"
+MODEL_CONTROLS="${MODEL_CONTROLS:-default}"
 FSDP="${ICI_FSDP_PARALLELISM:-8}"
 SHARDY="${SHARDY:-True}"
 SCAN_LAYERS="${SCAN_LAYERS:-False}"
@@ -42,6 +43,24 @@ USE_IOTA_EMBED="${USE_IOTA_EMBED:-False}"
 WEIGHT_DTYPE="${WEIGHT_DTYPE:-float32}"
 MU_DTYPE="${MU_DTYPE:-float32}"
 INIT_WEIGHTS_SEED="${INIT_WEIGHTS_SEED:-0}"
+
+MODEL_ARGS=()
+case "$MODEL_CONTROLS" in
+  default) ;;
+  llama31_mlperf)
+    [[ "$MODEL_NAME" == "llama3.1-8b" ]] ||
+      die "MODEL_CONTROLS=llama31_mlperf requires MODEL_NAME=llama3.1-8b"
+    MODEL_ARGS=(
+      query_pre_attn_scalar=0.08838834764831843
+      rope_use_scale=False
+      normalize_embedding_logits=False
+      megatron_init_std=0.02
+      megatron_residual_scale=True
+      num_vocab_tiling=1
+    )
+    ;;
+  *) die "bad MODEL_CONTROLS '$MODEL_CONTROLS' (expected default or llama31_mlperf)" ;;
+esac
 
 case "$MODE" in
   mxfp4)
@@ -133,6 +152,7 @@ CMD=("$PYTHON_BIN" -m maxtext.trainers.pre_train.train "$MAXTEXT_CONFIG"
   "mu_dtype=${MU_DTYPE}" "use_iota_embed=${USE_IOTA_EMBED}" dataset_type=synthetic
   logits_dot_in_fp32=False dtype=bfloat16 "per_device_batch_size=${PER_DEVICE_BATCH}"
   "global_batch_size_to_train_on=${GLOBAL_BATCH_SIZE}" "init_weights_seed=${INIT_WEIGHTS_SEED}"
+  "${MODEL_ARGS[@]}"
   "max_target_length=${MAX_TARGET_LENGTH}" "shardy=${SHARDY}" packing=True max_segments_per_seq=32
   "steps=${STEPS}" "use_jax_aiter=${USE_AITER}" "run_name=${MODE}"
   "quantization=${QUANTIZATION}" "${MODE_ARGS[@]}" "enable_nnx=${ENABLE_NNX}" "pure_nnx=${ENABLE_NNX}"
@@ -140,7 +160,7 @@ CMD=("$PYTHON_BIN" -m maxtext.trainers.pre_train.train "$MAXTEXT_CONFIG"
 
 print_recipe() {
   printf '%s\n' "=== RESOLVED_RECIPE_BEGIN ==="
-  printf 'runner=performance mode=%s label=%s processes=1 steps=%s measurement_window=completed_steps_40_49\n' "$MODE" "$LABEL" "$STEPS"
+  printf 'runner=performance mode=%s label=%s model=%s model_controls=%s processes=1 steps=%s measurement_window=completed_steps_40_49\n' "$MODE" "$LABEL" "$MODEL_NAME" "$MODEL_CONTROLS" "$STEPS"
   printf 'quantization=%s attention=%s use_jax_aiter=%s scan_layers=%s remat_policy=%s\n' "${QUANTIZATION:-none}" "$ATTENTION" "$USE_AITER" "$SCAN_LAYERS" "$REMAT_POLICY"
   printf 'autotune=%s weight_dtype=%s mu_dtype=%s use_iota_embed=%s batch=%s global_batch=%s sequence=%s init_seed=%s mem_fraction=%s\n' "$AUTOTUNE_LEVEL" "$WEIGHT_DTYPE" "$MU_DTYPE" "$USE_IOTA_EMBED" "$PER_DEVICE_BATCH" "$GLOBAL_BATCH_SIZE" "$MAX_TARGET_LENGTH" "$INIT_WEIGHTS_SEED" "$MEMFRAC"
   printf 'fsdp=%s shardy=%s scheduler=nvidia combine_threshold=%s enable_nnx=%s\n' "$FSDP" "$SHARDY" "$COMBINE_TH_BYTES" "$ENABLE_NNX"

--- a/scripts/recipes/run_nvfp4_match_8b.sh
+++ b/scripts/recipes/run_nvfp4_match_8b.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Single-process Llama 3.1 8B publication throughput runner.
+#
+# Usage:
+#   bash scripts/recipes/run_nvfp4_match_8b.sh \
+#     mxfp4|te_fp8_currentscaling|bf16 OUT_ROOT [50]
+#
+# Canonical in-container roots remain /ruvaidya/aiter_proj. Colleagues using a
+# different mount can set PROJECT_ROOT, JAX_AITER_ROOT, and/or MAXTEXT_ROOT.
+# RECIPE_DRY_RUN=1 resolves and prints the recipe without importing JAX or
+# launching MaxText.
+set -euo pipefail
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 2; }
+is_true() { [[ "${1,,}" == "1" || "${1,,}" == "true" || "${1,,}" == "yes" ]]; }
+
+[[ $# -ge 2 && $# -le 3 ]] || die "usage: $0 MODE OUT_ROOT [50]"
+MODE="$1"
+OUT_ROOT="$2"
+STEPS="${3:-50}"
+[[ "$STEPS" == "50" ]] || die "publication performance runs are exactly 50 steps"
+
+PROJECT_ROOT="${PROJECT_ROOT:-/ruvaidya/aiter_proj}"
+JAX_AITER_ROOT="${JAX_AITER_ROOT:-${PROJECT_ROOT}/jax-aiter}"
+MAXTEXT_ROOT="${MAXTEXT_ROOT:-${PROJECT_ROOT}/maxtext}"
+MAXTEXT_CONFIG="${MAXTEXT_CONFIG:-src/maxtext/configs/base.yml}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+MEMFRAC="${XLA_PYTHON_CLIENT_MEM_FRACTION:-.97}"
+[[ "$MEMFRAC" == ".97" ]] || die "canonical mem fraction is .97; stop instead of lowering it"
+
+MODEL_NAME="${MODEL_NAME:-llama3.1-8b}"
+FSDP="${ICI_FSDP_PARALLELISM:-8}"
+SHARDY="${SHARDY:-True}"
+SCAN_LAYERS="${SCAN_LAYERS:-False}"
+PER_DEVICE_BATCH="${PER_DEVICE_BATCH:-4}"
+GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-32}"
+MAX_TARGET_LENGTH="${MAX_TARGET_LENGTH:-8192}"
+AUTOTUNE_LEVEL="${AUTOTUNE_LEVEL:-5}"
+COMBINE_TH_BYTES="${COMBINE_TH_BYTES:-67108864}"
+ENABLE_NNX="${ENABLE_NNX:-False}"
+USE_IOTA_EMBED="${USE_IOTA_EMBED:-False}"
+WEIGHT_DTYPE="${WEIGHT_DTYPE:-float32}"
+MU_DTYPE="${MU_DTYPE:-float32}"
+INIT_WEIGHTS_SEED="${INIT_WEIGHTS_SEED:-0}"
+
+case "$MODE" in
+  mxfp4)
+    LABEL="MXFP4"; QUANTIZATION="aiter_fp4"; USE_AITER=True
+    SR_KEY_MODE=maxtext_runtime_params_rng
+    ATTENTION="${ATTENTION:-aiter_flash}"
+    REMAT_POLICY="${REMAT_POLICY:-minimal_flash_save_fp4col}"
+    ;;
+  te_fp8_currentscaling)
+    LABEL="TE FP8 current scaling"; QUANTIZATION="te_fp8_currentscaling"; USE_AITER=False
+    SR_KEY_MODE=n/a
+    ATTENTION="${ATTENTION:-cudnn_flash_te}"
+    REMAT_POLICY="${REMAT_POLICY:-minimal_flash}"
+    ;;
+  bf16)
+    LABEL="BF16"; QUANTIZATION=""; USE_AITER=False
+    SR_KEY_MODE=n/a
+    ATTENTION="${ATTENTION:-cudnn_flash_te}"
+    REMAT_POLICY="${REMAT_POLICY:-minimal_flash}"
+    ;;
+  *) die "bad mode '$MODE' (expected mxfp4, te_fp8_currentscaling, or bf16)" ;;
+esac
+
+# Required ROCm/JAX safeguards. This publication runner is intentionally not a
+# profiler wrapper; profiling requires a separate, explicitly labeled process.
+export XLA_PYTHON_CLIENT_MEM_FRACTION="$MEMFRAC"
+export JAX_PLATFORMS=rocm
+export HIP_VISIBLE_DEVICES="${HIP_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}"
+export HIP_FORCE_DEV_KERNARG=1 HSA_FORCE_FINE_GRAIN_PCIE=1
+export ROCPROFILER_QUEUE_INTERPOSITION=0 ROCPROFILER_REGISTER_ENABLED=0
+export HSA_NO_SCRATCH_RECLAIM=1 GPU_MAX_HW_QUEUES=2
+export RCCL_WARP_SPEED_AUTO=0 NCCL_DEBUG="${NCCL_DEBUG:-VERSION}"
+export NVTE_ALLOW_NONDETERMINISTIC_ALGO=1 NVTE_USE_HIPBLASLT=1
+export NVTE_FUSED_ATTN=1 NVTE_FUSED_ATTN_CK=1 NVTE_FUSED_ATTN_AOTRITON=0
+export NVTE_CK_USES_FWD_V3=1 NVTE_CK_USES_BWD_V3=1
+export NVTE_CK_IS_V3_ATOMIC_FP32=1 NVTE_CK_HOW_V3_BF16_CVT=2
+export DECOUPLE_GCLOUD=TRUE
+export JA_ROOT_DIR="${JA_ROOT_DIR:-$JAX_AITER_ROOT}"
+export AITER_ASM_DIR="${AITER_ASM_DIR:-${JAX_AITER_ROOT}/third_party/aiter/hsa/}"
+export AITER_SYMBOL_VISIBLE=1 GPU_ARCHS="${GPU_ARCHS:-gfx950}"
+export PYTHONPATH="${MAXTEXT_ROOT}/src:${JAX_AITER_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+if [[ "$MODE" == "mxfp4" ]]; then
+  export FP4_SELECT="${FP4_SELECT:-dispatch}" AITER_FP4_ATTN=1
+  case "$FP4_SELECT" in
+    dispatch) export AITER_FP4_DISPATCH=1; unset AITER_FORCE_KERNEL_NAME AITER_FORCE_LOG2_K_SPLIT ;;
+    forced)
+      unset AITER_FP4_DISPATCH
+      export AITER_FORCE_KERNEL_NAME=_ZN5aiter42f4gemm_bf16_per1x32Fp4_BpreShuffle_256x256E
+      export AITER_FORCE_LOG2_K_SPLIT=0
+      ;;
+    heuristic) unset AITER_FP4_DISPATCH AITER_FORCE_KERNEL_NAME AITER_FORCE_LOG2_K_SPLIT ;;
+    *) die "bad FP4_SELECT '$FP4_SELECT' (expected dispatch, forced, or heuristic)" ;;
+  esac
+  export JA_FP4_HADAMARD_PASSES="${JA_FP4_HADAMARD_PASSES:-wgrad}"
+  export JA_FP4_SR_PASSES="${JA_FP4_SR_PASSES:-wgrad_col}"
+  export JA_FP4_DGRAD_PARTITION="${JA_FP4_DGRAD_PARTITION:-gather_packed}"
+  export JA_FP4_DGRAD_REUSE_FWD_COL="${JA_FP4_DGRAD_REUSE_FWD_COL:-1}"
+  export JA_FP4_REMAT_SAVE_COL="${JA_FP4_REMAT_SAVE_COL:-both}"
+  export JA_FP4_PACK_GATEUP_AG="${JA_FP4_PACK_GATEUP_AG:-1}"
+  export JA_MHA_BWD_ATOMIC_FP32=0 JA_MHA_BWD_BF16_CVT=2
+  export JA_MHA_FUSE_GQA_REDUCE=1 JA_MHA_ZERO_PAD=1
+  unset AITER_FP4_SR AITER_FUSED_QUANT_HADAMARD AITER_FP4_HADAMARD_OFF
+else
+  unset FP4_SELECT AITER_FP4_DISPATCH AITER_FP4_ATTN
+  unset JA_FP4_HADAMARD_PASSES JA_FP4_SR_PASSES JA_FP4_DGRAD_PARTITION
+  unset JA_FP4_DGRAD_REUSE_FWD_COL JA_FP4_REMAT_SAVE_COL JA_FP4_PACK_GATEUP_AG
+  unset JA_MHA_BWD_ATOMIC_FP32 JA_MHA_BWD_BF16_CVT JA_MHA_FUSE_GQA_REDUCE JA_MHA_ZERO_PAD
+fi
+
+MODE_ARGS=()
+if [[ "$USE_AITER" == "True" && "$ATTENTION" != "aiter_flash" ]]; then
+  MODE_ARGS+=(aiter_attention=False)
+elif [[ "$USE_AITER" != "True" && "$ATTENTION" == "aiter_flash" ]]; then
+  MODE_ARGS+=(aiter_gemm=False)
+fi
+
+XLA_BASE="--xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_enable_triton_gemm=false --xla_gpu_enable_cublaslt=True --xla_gpu_autotune_level=${AUTOTUNE_LEVEL}"
+XLA_SCHED="--xla_gpu_all_reduce_combine_threshold_bytes=${COMBINE_TH_BYTES} --xla_gpu_all_gather_combine_threshold_bytes=${COMBINE_TH_BYTES} --xla_gpu_reduce_scatter_combine_threshold_bytes=${COMBINE_TH_BYTES} --xla_gpu_enable_pipelined_all_gather=true --xla_gpu_enable_pipelined_reduce_scatter=true --xla_gpu_enable_pipelined_all_reduce=true --xla_gpu_enable_while_loop_double_buffering=false --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_enable_reduce_scatter_combine_by_dim=false --xla_disable_hlo_passes=rematerialization"
+XLA_SCAN_FALSE="--xla_gpu_enable_command_buffer= --xla_gpu_experimental_enable_fusion_autotuner=false --xla_gpu_enable_allocator_spatial_partitioning=false"
+export XLA_FLAGS="${XLA_BASE} ${XLA_SCHED} ${XLA_SCAN_FALSE}${EXTRA_XLA:+ ${EXTRA_XLA}}"
+
+OUTDIR="${OUT_ROOT}/${MODE}"
+LOGFILE="${OUTDIR}/train.log"
+CMD=("$PYTHON_BIN" -m maxtext.trainers.pre_train.train "$MAXTEXT_CONFIG"
+  hardware=gpu "model_name=${MODEL_NAME}" "attention=${ATTENTION}"
+  enable_checkpointing=False "ici_fsdp_parallelism=${FSDP}" ici_data_parallelism=1 ici_expert_parallelism=1
+  "remat_policy=${REMAT_POLICY}" "scan_layers=${SCAN_LAYERS}" "weight_dtype=${WEIGHT_DTYPE}"
+  "mu_dtype=${MU_DTYPE}" "use_iota_embed=${USE_IOTA_EMBED}" dataset_type=synthetic
+  logits_dot_in_fp32=False dtype=bfloat16 "per_device_batch_size=${PER_DEVICE_BATCH}"
+  "global_batch_size_to_train_on=${GLOBAL_BATCH_SIZE}" "init_weights_seed=${INIT_WEIGHTS_SEED}"
+  "max_target_length=${MAX_TARGET_LENGTH}" "shardy=${SHARDY}" packing=True max_segments_per_seq=32
+  "steps=${STEPS}" "use_jax_aiter=${USE_AITER}" "run_name=${MODE}"
+  "quantization=${QUANTIZATION}" "${MODE_ARGS[@]}" "enable_nnx=${ENABLE_NNX}" "pure_nnx=${ENABLE_NNX}"
+  "pure_nnx_decoder=${ENABLE_NNX}" "base_output_directory=${OUTDIR}")
+
+print_recipe() {
+  printf '%s\n' "=== RESOLVED_RECIPE_BEGIN ==="
+  printf 'runner=performance mode=%s label=%s processes=1 steps=%s measurement_window=completed_steps_40_49\n' "$MODE" "$LABEL" "$STEPS"
+  printf 'quantization=%s attention=%s use_jax_aiter=%s scan_layers=%s remat_policy=%s\n' "${QUANTIZATION:-none}" "$ATTENTION" "$USE_AITER" "$SCAN_LAYERS" "$REMAT_POLICY"
+  printf 'autotune=%s weight_dtype=%s mu_dtype=%s use_iota_embed=%s batch=%s global_batch=%s sequence=%s init_seed=%s mem_fraction=%s\n' "$AUTOTUNE_LEVEL" "$WEIGHT_DTYPE" "$MU_DTYPE" "$USE_IOTA_EMBED" "$PER_DEVICE_BATCH" "$GLOBAL_BATCH_SIZE" "$MAX_TARGET_LENGTH" "$INIT_WEIGHTS_SEED" "$MEMFRAC"
+  printf 'fsdp=%s shardy=%s scheduler=nvidia combine_threshold=%s enable_nnx=%s\n' "$FSDP" "$SHARDY" "$COMBINE_TH_BYTES" "$ENABLE_NNX"
+  printf 'hadamard_passes=%s sr_passes=%s dgrad_partition=%s dgrad_reuse_fwd_col=%s remat_save_col=%s pack_gateup_ag=%s\n' "${JA_FP4_HADAMARD_PASSES:-n/a}" "${JA_FP4_SR_PASSES:-n/a}" "${JA_FP4_DGRAD_PARTITION:-n/a}" "${JA_FP4_DGRAD_REUSE_FWD_COL:-n/a}" "${JA_FP4_REMAT_SAVE_COL:-n/a}" "${JA_FP4_PACK_GATEUP_AG:-n/a}"
+  printf 'fp4_select=%s fp4_attention_gemm=%s sr_key_mode=%s mha_fuse_gqa_reduce=%s mha_zero_pad=%s\n' "${FP4_SELECT:-n/a}" "${AITER_FP4_ATTN:-n/a}" "$SR_KEY_MODE" "${JA_MHA_FUSE_GQA_REDUCE:-n/a}" "${JA_MHA_ZERO_PAD:-n/a}"
+  printf 'te_atomic_fp32=%s te_bf16_cvt=%s ja_mha_atomic_fp32=%s ja_mha_bf16_cvt=%s\n' "$NVTE_CK_IS_V3_ATOMIC_FP32" "$NVTE_CK_HOW_V3_BF16_CVT" "${JA_MHA_BWD_ATOMIC_FP32:-n/a}" "${JA_MHA_BWD_BF16_CVT:-n/a}"
+  printf 'rocm_safeguards=jax_platforms:%s,queue_interposition:%s,register_enabled:%s,no_scratch_reclaim:%s,dev_kernarg:%s,fine_grain_pcie:%s\n' "$JAX_PLATFORMS" "$ROCPROFILER_QUEUE_INTERPOSITION" "$ROCPROFILER_REGISTER_ENABLED" "$HSA_NO_SCRATCH_RECLAIM" "$HIP_FORCE_DEV_KERNARG" "$HSA_FORCE_FINE_GRAIN_PCIE"
+  printf 'project_root=%s jax_aiter_root=%s maxtext_root=%s oom_policy=stop_and_report_no_memfrac_fallback\n' "$PROJECT_ROOT" "$JAX_AITER_ROOT" "$MAXTEXT_ROOT"
+  printf '%s\n' "=== RESOLVED_RECIPE_END ==="
+}
+
+if is_true "${RECIPE_DRY_RUN:-0}"; then
+  print_recipe
+  printf 'XLA_FLAGS=%s\n' "$XLA_FLAGS"
+  printf 'RESOLVED_ARG=%s\n' "${CMD[@]}"
+  exit 0
+fi
+
+[[ -d "$MAXTEXT_ROOT" ]] || die "MAXTEXT_ROOT does not exist: $MAXTEXT_ROOT"
+mkdir -p "$OUTDIR"
+[[ ! -e "$LOGFILE" ]] || die "train.log already exists; use a fresh output root: $LOGFILE"
+LAUNCH_MARKER="${OUTDIR}/.launch_once"
+if ! (set -o noclobber; printf '%s mode=%s pid=%s\n' "$(date -u)" "$MODE" "$$" >"$LAUNCH_MARKER") 2>/dev/null; then
+  die "launch already attempted for $OUTDIR; use a fresh output root"
+fi
+{ print_recipe; printf 'XLA_FLAGS=%s\n' "$XLA_FLAGS"; printf 'COMMAND='; printf ' %q' "${CMD[@]}"; printf '\n'; } | tee "$LOGFILE"
+start_ts="$(date +%s)"
+set +e
+(cd "$MAXTEXT_ROOT" && "${CMD[@]}") 2>&1 | tee -a "$LOGFILE"
+rc=${PIPESTATUS[0]}
+set -e
+printf '=== %s EXIT %s wall=%ss %s ===\n' "$MODE" "$rc" "$(( $(date +%s) - start_ts ))" "$(date -u)" | tee -a "$LOGFILE"
+exit "$rc"

--- a/tests/test_publication_perf_runner.sh
+++ b/tests/test_publication_perf_runner.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# CPU-only resolution tests; no Python, JAX, Docker, or GPU process is started.
+set -uo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+PERF_RUNNER="$ROOT/scripts/recipes/run_nvfp4_match_8b.sh"
+TTC_RUNNER="$ROOT/scripts/recipes/run_mlperf_ttc_8b.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+count_exact() {
+  local expected="$1" file="$2"
+  awk -v expected="$expected" '$0 == expected { count++ } END { print count + 0 }' "$file"
+}
+
+count_prefix() {
+  local prefix="$1" file="$2"
+  awk -v prefix="$prefix" 'index($0, prefix) == 1 { count++ } END { print count + 0 }' "$file"
+}
+
+assert_line() {
+  local expected="$1" file="$2" count
+  count="$(count_exact "$expected" "$file")"
+  [[ "$count" == 1 ]] || {
+    printf 'expected one line %q in %s, got %s\n' "$expected" "$file" "$count" >&2
+    return 1
+  }
+}
+
+assert_text() {
+  local expected="$1" file="$2"
+  awk -v expected="$expected" 'index($0, expected) { found=1 } END { exit !found }' "$file" || {
+    printf 'expected text %q in %s\n' "$expected" "$file" >&2
+    return 1
+  }
+}
+
+assert_absent() {
+  local unexpected="$1" file="$2"
+  ! awk -v unexpected="$unexpected" 'index($0, unexpected) { found=1 } END { exit !found }' "$file" || {
+    printf 'unexpected text %q in %s\n' "$unexpected" "$file" >&2
+    return 1
+  }
+}
+
+assert_one_quantization_arg() {
+  local file="$1" count
+  count="$(count_prefix "RESOLVED_ARG=quantization=" "$file")"
+  [[ "$count" == 1 ]] || {
+    printf 'expected one quantization arg in %s, got %s\n' "$file" "$count" >&2
+    return 1
+  }
+}
+
+clean_env() {
+  env -i PATH="$PATH" HOME="$TMP" RECIPE_DRY_RUN=1 \
+    PROJECT_ROOT=/opt/mxfp4-repro PYTHON_BIN=/not-executed/python3 "$@"
+}
+
+run_perf() {
+  local mode="$1" capture="$2"
+  clean_env bash "$PERF_RUNNER" "$mode" /outputs 50 >"$capture" 2>&1
+}
+
+run_ttc() {
+  local mode="$1" capture="$2"
+  clean_env bash "$TTC_RUNNER" "${mode}_ttc" "$mode" /outputs 6000 >"$capture" 2>&1
+}
+
+check_common() {
+  local capture="$1"
+  assert_text "autotune=5 weight_dtype=float32 mu_dtype=float32 use_iota_embed=False batch=4 global_batch=32 sequence=8192 init_seed=0 mem_fraction=.97" "$capture" &&
+    assert_line "RESOLVED_ARG=weight_dtype=float32" "$capture" &&
+    assert_line "RESOLVED_ARG=mu_dtype=float32" "$capture" &&
+    assert_line "RESOLVED_ARG=use_iota_embed=False" "$capture" &&
+    assert_line "RESOLVED_ARG=global_batch_size_to_train_on=32" "$capture" &&
+    assert_line "RESOLVED_ARG=init_weights_seed=0" "$capture" &&
+    assert_line "RESOLVED_ARG=scan_layers=False" "$capture" &&
+    assert_line "RESOLVED_ARG=enable_nnx=False" "$capture" &&
+    assert_line "RESOLVED_ARG=pure_nnx=False" "$capture" &&
+    assert_line "RESOLVED_ARG=pure_nnx_decoder=False" "$capture" &&
+    assert_text "project_root=/opt/mxfp4-repro jax_aiter_root=/opt/mxfp4-repro/jax-aiter maxtext_root=/opt/mxfp4-repro/maxtext" "$capture" &&
+    assert_text "rocm_safeguards=jax_platforms:rocm,queue_interposition:0,register_enabled:0,no_scratch_reclaim:1,dev_kernarg:1,fine_grain_pcie:1" "$capture" &&
+    assert_text "--xla_gpu_autotune_level=5" "$capture" &&
+    assert_one_quantization_arg "$capture"
+}
+
+test_perf_mxfp4_direct_mha() {
+  local capture="$TMP/perf-mxfp4"
+  run_perf mxfp4 "$capture" &&
+    check_common "$capture" &&
+    assert_text "mode=mxfp4 label=MXFP4 processes=1 steps=50 measurement_window=completed_steps_40_49" "$capture" &&
+    assert_line "RESOLVED_ARG=quantization=aiter_fp4" "$capture" &&
+    assert_line "RESOLVED_ARG=attention=aiter_flash" "$capture" &&
+    assert_line "RESOLVED_ARG=use_jax_aiter=True" "$capture" &&
+    assert_line "RESOLVED_ARG=remat_policy=minimal_flash_save_fp4col" "$capture" &&
+    assert_text "hadamard_passes=wgrad sr_passes=wgrad_col dgrad_partition=gather_packed dgrad_reuse_fwd_col=1 remat_save_col=both pack_gateup_ag=1" "$capture" &&
+    assert_text "fp4_select=dispatch fp4_attention_gemm=1 sr_key_mode=maxtext_runtime_params_rng mha_fuse_gqa_reduce=1 mha_zero_pad=1" "$capture" &&
+    assert_text "ja_mha_atomic_fp32=0 ja_mha_bf16_cvt=2" "$capture" &&
+    assert_absent "RESOLVED_ARG=aiter_attention=False" "$capture"
+}
+
+test_perf_te_current_scaling() {
+  local capture="$TMP/perf-te"
+  run_perf te_fp8_currentscaling "$capture" &&
+    check_common "$capture" &&
+    assert_text "mode=te_fp8_currentscaling label=TE FP8 current scaling processes=1 steps=50" "$capture" &&
+    assert_line "RESOLVED_ARG=quantization=te_fp8_currentscaling" "$capture" &&
+    assert_line "RESOLVED_ARG=attention=cudnn_flash_te" "$capture" &&
+    assert_line "RESOLVED_ARG=use_jax_aiter=False" "$capture" &&
+    assert_text "te_atomic_fp32=1 te_bf16_cvt=2" "$capture" &&
+    assert_absent "RESOLVED_ARG=quantization=fp8" "$capture"
+}
+
+test_perf_bf16_no_quantization() {
+  local capture="$TMP/perf-bf16"
+  run_perf bf16 "$capture" &&
+    check_common "$capture" &&
+    assert_text "mode=bf16 label=BF16 processes=1 steps=50" "$capture" &&
+    assert_line "RESOLVED_ARG=quantization=" "$capture" &&
+    assert_line "RESOLVED_ARG=attention=cudnn_flash_te" "$capture" &&
+    assert_text "quantization=none attention=cudnn_flash_te" "$capture"
+}
+
+test_convergence_modes() {
+  local mode capture quant label attention
+  for mode in mxfp4 te_fp8_currentscaling bf16; do
+    capture="$TMP/ttc-$mode"
+    case "$mode" in
+      mxfp4) quant=aiter_fp4; label=MXFP4; attention=aiter_flash ;;
+      te_fp8_currentscaling) quant=te_fp8_currentscaling; label="TE FP8 current scaling"; attention=cudnn_flash_te ;;
+      bf16) quant=""; label=BF16; attention=cudnn_flash_te ;;
+    esac
+    run_ttc "$mode" "$capture" &&
+      check_common "$capture" &&
+      assert_text "runner=convergence tag=${mode}_ttc mode=${mode} label=${label} processes=1 steps=6000" "$capture" &&
+      assert_line "RESOLVED_ARG=quantization=$quant" "$capture" &&
+      assert_line "RESOLVED_ARG=attention=$attention" "$capture" &&
+      assert_line "RESOLVED_ARG=enable_mlperf_logging=True" "$capture" || return 1
+  done
+}
+
+test_rejects_stale_aliases() {
+  local alias capture
+  for alias in fp8 te_fp8 mxfp4_mlponly; do
+    capture="$TMP/reject-$alias"
+    if run_perf "$alias" "$capture"; then
+      printf 'stale alias %s unexpectedly succeeded\n' "$alias" >&2
+      return 1
+    fi
+  done
+}
+
+test_rejects_noncanonical_mem_fraction() {
+  local capture="$TMP/bad-memfrac"
+  if env -i PATH="$PATH" HOME="$TMP" RECIPE_DRY_RUN=1 \
+      XLA_PYTHON_CLIENT_MEM_FRACTION=.90 \
+      bash "$PERF_RUNNER" mxfp4 /outputs 50 >"$capture" 2>&1; then
+    printf 'noncanonical mem fraction unexpectedly succeeded\n' >&2
+    return 1
+  fi
+  assert_text "canonical mem fraction is .97" "$capture"
+}
+
+test_atomic_launch_guard() {
+  local fake_root="$TMP/fake-project"
+  local out_root="$TMP/guarded-output"
+  local first_capture="$TMP/guard-first"
+  local second_capture="$TMP/guard-second"
+  mkdir -p "$fake_root/maxtext"
+
+  # /bin/false stands in for Python: the first launch claims the marker and
+  # exits without importing JAX; the second must fail before starting it.
+  env -i PATH="$PATH" HOME="$TMP" PROJECT_ROOT="$fake_root" PYTHON_BIN=/bin/false \
+    bash "$PERF_RUNNER" mxfp4 "$out_root" 50 >"$first_capture" 2>&1
+  [[ "$?" == 1 ]] || {
+    printf 'first guarded launch did not reach the fake executable\n' >&2
+    return 1
+  }
+  if env -i PATH="$PATH" HOME="$TMP" PROJECT_ROOT="$fake_root" PYTHON_BIN=/bin/false \
+      bash "$PERF_RUNNER" mxfp4 "$out_root" 50 >"$second_capture" 2>&1; then
+    printf 'duplicate guarded launch unexpectedly succeeded\n' >&2
+    return 1
+  fi
+  assert_text "train.log already exists; use a fresh output root" "$second_capture" || return 1
+  [[ "$(count_prefix "=== RESOLVED_RECIPE_BEGIN ===" "$out_root/mxfp4/train.log")" == 1 ]] || return 1
+
+  # The marker remains authoritative even if a user removes the log.
+  rm "$out_root/mxfp4/train.log"
+  if env -i PATH="$PATH" HOME="$TMP" PROJECT_ROOT="$fake_root" PYTHON_BIN=/bin/false \
+      bash "$PERF_RUNNER" mxfp4 "$out_root" 50 >"$second_capture" 2>&1; then
+    printf 'launch with an existing marker unexpectedly succeeded\n' >&2
+    return 1
+  fi
+  assert_text "launch already attempted" "$second_capture"
+}
+
+tests=(
+  test_perf_mxfp4_direct_mha
+  test_perf_te_current_scaling
+  test_perf_bf16_no_quantization
+  test_convergence_modes
+  test_rejects_stale_aliases
+  test_rejects_noncanonical_mem_fraction
+  test_atomic_launch_guard
+)
+failures=0
+for test_name in "${tests[@]}"; do
+  if "$test_name"; then
+    printf 'PASS %s\n' "$test_name"
+  else
+    printf 'FAIL %s\n' "$test_name"
+    failures=$((failures + 1))
+  fi
+done
+printf '%d passed, %d failed\n' "$(( ${#tests[@]} - failures ))" "$failures"
+exit "$failures"

--- a/tests/test_publication_perf_runner.sh
+++ b/tests/test_publication_perf_runner.sh
@@ -89,7 +89,7 @@ test_perf_mxfp4_direct_mha() {
   local capture="$TMP/perf-mxfp4"
   run_perf mxfp4 "$capture" &&
     check_common "$capture" &&
-    assert_text "mode=mxfp4 label=MXFP4 processes=1 steps=50 measurement_window=completed_steps_40_49" "$capture" &&
+    assert_text "mode=mxfp4 label=MXFP4 model=llama3.1-8b model_controls=default processes=1 steps=50 measurement_window=completed_steps_40_49" "$capture" &&
     assert_line "RESOLVED_ARG=quantization=aiter_fp4" "$capture" &&
     assert_line "RESOLVED_ARG=attention=aiter_flash" "$capture" &&
     assert_line "RESOLVED_ARG=use_jax_aiter=True" "$capture" &&
@@ -104,7 +104,7 @@ test_perf_te_current_scaling() {
   local capture="$TMP/perf-te"
   run_perf te_fp8_currentscaling "$capture" &&
     check_common "$capture" &&
-    assert_text "mode=te_fp8_currentscaling label=TE FP8 current scaling processes=1 steps=50" "$capture" &&
+    assert_text "mode=te_fp8_currentscaling label=TE FP8 current scaling model=llama3.1-8b model_controls=default processes=1 steps=50" "$capture" &&
     assert_line "RESOLVED_ARG=quantization=te_fp8_currentscaling" "$capture" &&
     assert_line "RESOLVED_ARG=attention=cudnn_flash_te" "$capture" &&
     assert_line "RESOLVED_ARG=use_jax_aiter=False" "$capture" &&
@@ -116,7 +116,7 @@ test_perf_bf16_no_quantization() {
   local capture="$TMP/perf-bf16"
   run_perf bf16 "$capture" &&
     check_common "$capture" &&
-    assert_text "mode=bf16 label=BF16 processes=1 steps=50" "$capture" &&
+    assert_text "mode=bf16 label=BF16 model=llama3.1-8b model_controls=default processes=1 steps=50" "$capture" &&
     assert_line "RESOLVED_ARG=quantization=" "$capture" &&
     assert_line "RESOLVED_ARG=attention=cudnn_flash_te" "$capture" &&
     assert_text "quantization=none attention=cudnn_flash_te" "$capture"
@@ -162,6 +162,19 @@ test_rejects_noncanonical_mem_fraction() {
   assert_text "canonical mem fraction is .97" "$capture"
 }
 
+test_llama31_mlperf_model_controls() {
+  local capture="$TMP/perf-llama31-mlperf"
+  clean_env MODEL_CONTROLS=llama31_mlperf \
+    bash "$PERF_RUNNER" mxfp4 /outputs 50 >"$capture" 2>&1 &&
+    assert_text "model=llama3.1-8b model_controls=llama31_mlperf" "$capture" &&
+    assert_line "RESOLVED_ARG=query_pre_attn_scalar=0.08838834764831843" "$capture" &&
+    assert_line "RESOLVED_ARG=rope_use_scale=False" "$capture" &&
+    assert_line "RESOLVED_ARG=normalize_embedding_logits=False" "$capture" &&
+    assert_line "RESOLVED_ARG=megatron_init_std=0.02" "$capture" &&
+    assert_line "RESOLVED_ARG=megatron_residual_scale=True" "$capture" &&
+    assert_line "RESOLVED_ARG=num_vocab_tiling=1" "$capture"
+}
+
 test_atomic_launch_guard() {
   local fake_root="$TMP/fake-project"
   local out_root="$TMP/guarded-output"
@@ -202,6 +215,7 @@ tests=(
   test_convergence_modes
   test_rejects_stale_aliases
   test_rejects_noncanonical_mem_fraction
+  test_llama31_mlperf_model_controls
   test_atomic_launch_guard
 )
 failures=0


### PR DESCRIPTION
## Summary
- hoist deterministic stochastic-rounding streams out of cast chunk loops
- add guarded single-leg runners for MXFP4, TE FP8 current scaling, and BF16 performance/convergence
- make the convergence-aligned Llama 3.1 model controls an explicit tested performance profile
- document the 8x MI355X MaxText recipe with CPU-only resolution tests and MLPerf logging guidance

## Test plan
- [x] `bash -n` on both runners and the shell test
- [x] `bash tests/test_publication_perf_runner.sh`
- [x] `python3 -m pytest -q ci/perf/test_parse_perf_log.py`

Performance results are intentionally omitted pending review and approval.