### PR TITLE
docs(alpha2): recommend the self-contained +full wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,22 @@ python3 -c "import jax; print(jax.devices())"
 
 ### 3. Install JAX-AITER
 
-Download the alpha2 wheel from the
-[GitHub release](https://github.com/ROCm/jax-aiter/releases/tag/v0.1.0-alpha2),
-then install it:
+Download a wheel from the
+[GitHub release](https://github.com/ROCm/jax-aiter/releases/tag/v0.1.0-alpha2).
+The `+full` wheel is recommended: it is complete on its own, with nothing to
+fetch afterwards.
 
 ```bash
 python3 -m pip install \
-  ./jax_aiter-0.1.0a2-cp312-cp312-manylinux_2_39_x86_64.whl
+  ./jax_aiter-0.1.0a2+full-cp312-cp312-manylinux_2_39_x86_64.whl
 ```
 
-The default wheel is `gfx950`-only and contains all APIs, FFI shims, and
-non-MHA runtime libraries. PyPI publication is intentionally not automated yet;
-the release notes will state when `pip install jax-aiter==0.1.0a2` is available.
+Both wheels are `gfx950`-only. The `+full` wheel is roughly 433 MB and bundles
+the MHA JIT libraries. The plain `0.1.0a2` wheel is roughly 30 MB and omits
+them, so it needs `jax-aiter-fetch-mha` before flash attention works — prefer
+it when download or image size matters. PyPI publication is intentionally not
+automated yet; the release notes will state when `pip install
+jax-aiter==0.1.0a2` is available.
 
 Verify the basic install:
 
@@ -83,9 +87,12 @@ PY
 
 ### 4. Add flash attention when needed
 
-The two MHA JIT libraries are omitted from the default wheel because they
-expand to multiple gigabytes. Download the matching, checksummed `gfx950`
-artifacts instead of compiling them:
+Skip this step if you installed the `+full` wheel; it already bundles the MHA
+JIT libraries.
+
+The plain wheel omits those two libraries because they expand to multiple
+gigabytes. Download the matching, checksummed `gfx950` artifacts instead of
+compiling them:
 
 ```bash
 jax-aiter-fetch-mha
@@ -122,7 +129,7 @@ y_fused, residual_out = rms_norm_with_add(
 y_silu = silu_and_mul(jnp.concatenate([gate_bf16, up_bf16], axis=-1))
 ```
 
-After `jax-aiter-fetch-mha`:
+With the `+full` wheel, or after `jax-aiter-fetch-mha` on the plain wheel:
 
 ```python
 from jax_aiter.mha import flash_attn_func, flash_attn_varlen

--- a/docs/RELEASE_NOTES_v0.1.0-alpha2.md
+++ b/docs/RELEASE_NOTES_v0.1.0-alpha2.md
@@ -16,17 +16,20 @@ performance results will be published separately in the ROCm blog.
 
 ## Wheels
 
-Two wheels are attached to the GitHub release:
+Two wheels are attached to the GitHub release. **Most users want the `+full`
+wheel**, which is complete on its own:
 
-- `jax_aiter-0.1.0a2-...manylinux_2_39_x86_64.whl`
-  - default installation;
-  - all public APIs and thin FFI shims;
-  - gfx950 HSA files only;
-  - MHA JIT libraries downloaded on demand.
-- `jax_aiter-0.1.0a2+full-...manylinux_2_39_x86_64.whl`
-  - GitHub-only convenience artifact;
-  - includes the MHA JIT libraries;
-  - intended for environments that cannot download runtime assets later.
+- `jax_aiter-0.1.0a2+full-...manylinux_2_39_x86_64.whl` — **recommended**
+  - everything in one download, including the MHA JIT libraries;
+  - nothing to fetch after installing;
+  - roughly 433 MB, about 2.5 GB installed.
+- `jax_aiter-0.1.0a2-...manylinux_2_39_x86_64.whl` — small alternative
+  - all public APIs, thin FFI shims, and gfx950 HSA files;
+  - omits the two multi-GB MHA JIT libraries, so it is roughly 30 MB;
+  - `jax-aiter-fetch-mha` downloads those libraries on first use;
+  - carries the plain version because it is the PyPI-shaped artifact, though
+    alpha2 is not published to PyPI. Prefer it when download size or image
+    size matters more than a self-contained install.
 
 The `manylinux_2_39` tag reports what the wheels actually require: the bundled
 AITER JIT libraries are built on Ubuntu 24.04 and need `GLIBCXX_3.4.31`. Broad
@@ -48,16 +51,19 @@ python3 -m pip install \
   "jax-rocm7-plugin==0.11.0" "jax-rocm7-pjrt==0.11.0"
 ```
 
-Install the downloaded default wheel:
+Install the recommended `+full` wheel, which needs no follow-up download:
+
+```bash
+python3 -m pip install \
+  ./jax_aiter-0.1.0a2+full-cp312-cp312-manylinux_2_39_x86_64.whl
+python3 -c "from jax_aiter.mha import flash_attn_func; print('MHA ready')"
+```
+
+If you took the small wheel instead, add flash attention separately:
 
 ```bash
 python3 -m pip install \
   ./jax_aiter-0.1.0a2-cp312-cp312-manylinux_2_39_x86_64.whl
-```
-
-Add flash attention when needed:
-
-```bash
 jax-aiter-fetch-mha
 python3 -c "from jax_aiter.mha import flash_attn_func; print('MHA ready')"
 ```
@@ -72,7 +78,7 @@ system `site-packages`.
 - JIT libraries rebuild only when the AITER pin, architecture, or JIT recipe
   changes; unrelated integration patches do not invalidate them.
 - PR and nightly tests are selected by `gpu`, `multigpu`, and `slow` markers.
-- The default wheel is gfx950-only and omits only the large MHA JIT libraries.
+- Both wheels are gfx950-only; the smaller one omits just the MHA JIT libraries.
 - HIP failures now print the HIP error, source file, and line before aborting.
 - Dead compatibility helpers, unbuildable registry entries, and the
   experimental unbuilt FP8 GEMM module were removed.
@@ -96,7 +102,7 @@ CPU CI.
 
 - Alpha2 supports `gfx950` only.
 - Python 3.12 is required.
-- The default wheel needs `jax-aiter-fetch-mha` before importing
-  `jax_aiter.mha`.
+- The smaller plain wheel needs `jax-aiter-fetch-mha` before importing
+  `jax_aiter.mha`. The recommended `+full` wheel does not.
 - PyPI publication is a separate, explicitly approved step. Until the release
   notes say otherwise, install the wheel from the GitHub release.

--- a/docs/recipes/mxfp4_llama3_8b_maxtext.md
+++ b/docs/recipes/mxfp4_llama3_8b_maxtext.md
@@ -48,11 +48,14 @@ python3 -m pip install \
   "jax==0.11.0" "jaxlib==0.11.0" \
   "jax-rocm7-plugin==0.11.0" "jax-rocm7-pjrt==0.11.0"
 
-WHEEL=jax_aiter-0.1.0a2-cp312-cp312-manylinux_2_39_x86_64.whl
+# The +full wheel is self-contained. The plain wheel is far smaller but then
+# needs `jax-aiter-fetch-mha` before flash attention works.
+# The '+' is percent-encoded as %2B in the download URL, not in the filename.
+BASE=https://github.com/ROCm/jax-aiter/releases/download/v0.1.0-alpha2
+WHEEL='jax_aiter-0.1.0a2+full-cp312-cp312-manylinux_2_39_x86_64.whl'
 curl -fL -o "/tmp/$WHEEL" \
-  "https://github.com/ROCm/jax-aiter/releases/download/v0.1.0-alpha2/$WHEEL"
+  "$BASE/jax_aiter-0.1.0a2%2Bfull-cp312-cp312-manylinux_2_39_x86_64.whl"
 python3 -m pip install "/tmp/$WHEEL"
-jax-aiter-fetch-mha
 
 python3 - <<'PY'
 import jax


### PR DESCRIPTION
## Summary

- Point users at the `+full` wheel as the recommended alpha2 install, since it is complete on its own and needs no follow-up download.
- Document the plain `0.1.0a2` wheel as the smaller alternative that still requires `jax-aiter-fetch-mha`.
- No build changes: both wheels are produced and published exactly as before, and the plain version stays the PyPI-shaped artifact.

## Why

Alpha1 published the complete wheel under the plain version and tagged the stripped one `+lite`. Alpha2 reversed that polarity, so the unadorned wheel is the one missing flash attention. For a GitHub-only release that is a surprising default: download size matters much less than getting a working install in one step, and a `+full` local version tag can never go to PyPI anyway.

## Notes

- The recipe now installs `+full` and drops its `jax-aiter-fetch-mha` call, which is redundant for that wheel. Its `flash_attn_func` import still succeeds.
- The `+` is percent-encoded as `%2B` in the download URL. Verified against the alpha1 `+lite` asset: GitHub reports the canonical URL with `%2B`, and both forms return 200.

## Test plan

- [x] CPU CI scripts pass locally: `ci/test_jit_libs_manifest.py`, `ci/perf/test_parse_perf_log.py`, `ci/check_manylinux_policy.py --selftest`
- [x] Recipe bash block extracted and `bash -n` clean
- [x] Docs remain free of throughput and speedup claims
- [ ] PR `cpu checks` and `gpu tests (1x MI355)`