### PR TITLE
fix(release): grant the non-root validation container the render group

### DIFF
--- a/scripts/validate_wheel.sh
+++ b/scripts/validate_wheel.sh
@@ -81,13 +81,32 @@ else
   SMOKE="python /test/smoke_fp4_gemm.py && python /test/smoke_mha.py"
 fi
 
+# This container runs as a non-root user on purpose, which means it can only
+# open the GPU device nodes if that user is in the groups owning them. Group
+# NAMES resolve against the container's /etc/group, which need not agree with
+# the host, so pass the host's numeric GIDs. Without them /dev/dri is mounted
+# yet hipInit still reports HIP_ERROR_NoDevice, and whether it works depends on
+# which groups happen to own the device nodes on a given runner.
+mapfile -t DEV_GIDS < <(
+  for dev in /dev/kfd /dev/dri/renderD*; do
+    [[ -e "$dev" ]] || continue
+    stat -c '%g' "$dev"
+  done | sort -u
+)
+GROUP_ARGS=(--group-add video)
+for gid in "${DEV_GIDS[@]}"; do
+  GROUP_ARGS+=(--group-add "$gid")
+done
+echo "[validate_wheel] device groups: ${GROUP_ARGS[*]}"
+
 # Run the smoke test(s) in a fresh sibling container with GPU access.
+# One GPU is enough for these smokes, and it matches the 1x validation job.
 echo "[validate_wheel] docker run smoke ($VARIANT)"
 docker run --rm \
-  --device=/dev/kfd --device=/dev/dri --group-add video \
+  --device=/dev/kfd --device=/dev/dri "${GROUP_ARGS[@]}" \
   --user "$(id -u):$(id -g)" \
   -e HOME=/tmp/ja-home -e XDG_CACHE_HOME=/tmp/ja-home/.cache \
-  -e GPU_ARCHS=gfx950 \
+  -e GPU_ARCHS=gfx950 -e HIP_VISIBLE_DEVICES="${HIP_VISIBLE_DEVICES:-0}" \
   -v "$REPO/dist:/dist:ro" \
   -v "$REPO/docker/validation:/test:ro" \
   "$IMAGE_TAG" \


### PR DESCRIPTION
## Summary

The publish run [31720815344](https://github.com/ROCm/jax-aiter/actions/runs/31720815344) failed in "Validate default wheel in a clean TheRock container" with:

```text
E0813 17:21:51 rocm_platform.cc:52] failed call to hipInit: HIP_ERROR_NoDevice
FP4 GEMM smoke FAIL: RuntimeError: Unable to initialize backend 'rocm'
```

Nothing was published: the three publish steps are gated behind validation and were correctly skipped.

## Root cause

The validation container runs as a non-root user on purpose, to prove a downstream user can install and run the wheel. It was launched with only `--group-add video`. On this stack the GPU device nodes are `root:render` with mode `crw-rw----`, so group membership is the only thing granting access, and `video` grants none of it. The devices were mounted but unopenable, so `hipInit` saw no device.

Verified directly on an MI355 host:

```text
groups {1000, video}       -> DENIED  /dev/kfd, /dev/dri/renderD128 (present, cannot open)
groups {1000, video, 109}  -> OPEN OK /dev/kfd, /dev/dri/renderD128
```

That also explains why this step passed in the earlier publish-disabled run and failed here: different ephemeral runners, and the outcome depended on which groups happened to own the device nodes.

## Fix

Pass the host's **numeric** GIDs for `/dev/kfd` and `/dev/dri/renderD*`, deduplicated, rather than the name `render`. Group names resolve against the container's `/etc/group`, which need not match the host, so a name is not reliable here.

Also pin the smoke to one GPU via `HIP_VISIBLE_DEVICES`, which matches the 1x validation job and silences a multi-GPU RCCL shared-memory warning these single-GPU smokes cannot hit.

## Test plan

- [x] `bash -n scripts/validate_wheel.sh`
- [x] Device-open behaviour verified both ways in a non-root container (above)
- [x] Group discovery deduplicates: `--group-add video --group-add 109` on an 8-GPU host
- [ ] PR `cpu checks` and `gpu tests (1x MI355)`
- [ ] Re-dispatch `release-publish.yml` with `publish=true` after merge