### PR TITLE
fix(release): publish the validation image instead of rebuilding it per run

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,6 +31,8 @@ concurrency:
 
 permissions:
   contents: write
+  # Pull the published clean-room validation image.
+  packages: read
 
 env:
   BUILD_IMAGE: ghcr.io/rocm/jax-manylinux_2_28-therock-7.14:7.14
@@ -204,6 +206,13 @@ jobs:
         with:
           name: jax-aiter-alpha2-wheels
           path: dist
+
+      - name: Log in to ghcr.io
+        # validate_wheel.sh pulls the prebuilt clean-room image instead of
+        # rebuilding it; without this it would silently fall back to a build.
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Validate default wheel in a clean TheRock container
         run: |

--- a/.github/workflows/validation-image.yml
+++ b/.github/workflows/validation-image.yml
@@ -1,0 +1,101 @@
+name: Validation image (build + publish)
+
+# Publishes the clean-room image that scripts/validate_wheel.sh runs wheels in.
+#
+# Why this exists: validate_wheel.sh used to `docker build` this image on every
+# release run. That meant fetching a 3.39 GB ROCm base layer plus reinstalling
+# the JAX stack each time, and on a runner without those layers cached the step
+# ran past the job timeout -- it blocked three alpha2 release attempts. Building
+# once and pulling thereafter removes that from the release path.
+#
+# The tag is derived from docker/validation/Dockerfile.lite by
+# ci/validation_image_id.sh, so a recipe edit produces a new tag and preflight
+# rebuilds instead of validating against a stale environment.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/validation/**'
+      - 'ci/validation_image_id.sh'
+      - '.github/workflows/validation-image.yml'
+
+concurrency:
+  group: validation-image
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: build + publish validation image
+    runs-on: build-only-jax-aiter
+    timeout-minutes: 90
+    steps:
+      - name: Fix permissions from a previous container run
+        run: |
+          if [ -d "${{ github.workspace }}" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "${{ github.workspace }}" || true
+          fi
+
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Resolve the content-addressed image reference
+        id: ref
+        run: |
+          image="$(bash ci/validation_image_id.sh)"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "resolved $image"
+
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Skip when this recipe is already published
+        id: preflight
+        run: |
+          if docker manifest inspect "${{ steps.ref.outputs.image }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "already published; nothing to do"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build
+        if: steps.preflight.outputs.exists != 'true'
+        run: |
+          docker build -t "${{ steps.ref.outputs.image }}" \
+            -f docker/validation/Dockerfile.lite docker/validation
+
+      - name: Verify the image can import the JAX ROCm stack
+        if: steps.preflight.outputs.exists != 'true'
+        # No GPU on this runner, so only the import path is checked here; the
+        # release job exercises the GPU path when it validates a wheel.
+        run: |
+          docker run --rm "${{ steps.ref.outputs.image }}" \
+            python3 -c "import jax, jaxlib, jax_rocm7_plugin; print('validation image OK', jax.__version__)"
+
+      - name: Push
+        if: steps.preflight.outputs.exists != 'true'
+        run: docker push "${{ steps.ref.outputs.image }}"
+
+      - name: Summary
+        run: |
+          {
+            echo "### Validation image"
+            echo
+            echo '```text'
+            echo "${{ steps.ref.outputs.image }}"
+            echo '```'
+            if [ "${{ steps.preflight.outputs.exists }}" = "true" ]; then
+              echo "Already published; build skipped."
+            else
+              echo "Built and pushed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/ci/validation_image_id.sh
+++ b/ci/validation_image_id.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Print the content-addressed reference of the clean-room validation image.
+#
+# Single source of truth for that reference: validation-image.yml builds and
+# pushes it, scripts/validate_wheel.sh pulls it. The tag is derived from the
+# Dockerfile, so editing the recipe yields a new tag and the next run rebuilds
+# instead of silently validating against a stale environment.
+#
+# Env overrides:
+#   JA_VALIDATE_IMAGE_REPO  registry/repository (default ghcr.io/rocm/jax-aiter-validate)
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE="$REPO/docker/validation/Dockerfile.lite"
+IMAGE_REPO="${JA_VALIDATE_IMAGE_REPO:-ghcr.io/rocm/jax-aiter-validate}"
+
+if [[ ! -f "$DOCKERFILE" ]]; then
+  echo "ERROR: missing $DOCKERFILE" >&2
+  exit 1
+fi
+
+# 12 hex chars is plenty to separate recipes and keeps the tag readable.
+RECIPE_HASH="$(sha256sum "$DOCKERFILE" | cut -c1-12)"
+echo "${IMAGE_REPO}:v${RECIPE_HASH}"

--- a/docker/validation/Dockerfile.lite
+++ b/docker/validation/Dockerfile.lite
@@ -11,9 +11,18 @@
 #
 # TheRock 7.14 GA ships ROCm through the rocm-sdk pip packages (no /opt/rocm)
 # but no importable JAX stack. Install the same four PyPI distributions CI uses.
-# Runtime-only base: validation installs and runs a wheel; it never invokes a
-# compiler. The dev image adds a multi-GB LLVM layer for no benefit here.
-FROM ghcr.io/rocm/jax-base-ubu24.therock-7.14:7.14
+#
+# Base choice is about transfer cost, not content. The runtime-only
+# jax-base-ubu24 image would be the natural fit -- validation never invokes a
+# compiler -- but its 3.39 GB ROCm layer has a different digest from the
+# jax-dev-ubu24 one, and only this image ever pulls it. That left a cold runner
+# spending over an hour fetching it, which timed out three release attempts.
+# jax-dev-ubu24 is pulled by ci.yml on every PR, so the same mi355 nodes almost
+# always have its layers cached and docker reuses them by digest. The extra LLVM
+# layer is unused here; nothing in the smoke tests compiles, and the clean-room
+# guarantees that matter are unchanged: no AITER source, no MaxText, no build of
+# this repo, and the wheel is pip-installed as a non-root user.
+FROM ghcr.io/rocm/jax-dev-ubu24.therock-7.14:7.14
 
 ARG JAX_VERSION=0.11.0
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,6 +40,20 @@ Do not run `make clean` casually. It removes multi-hour JIT outputs.
 `make clean-stage` removes wheel staging without deleting
 `build/aiter_build`.
 
+## Clean-room validation image
+
+`.github/workflows/validation-image.yml` publishes the image that
+`scripts/validate_wheel.sh` installs wheels into, as
+`ghcr.io/rocm/jax-aiter-validate:v<recipe-hash>`. The tag comes from
+`ci/validation_image_id.sh`, which hashes
+`docker/validation/Dockerfile.lite`, so editing the recipe yields a new tag and
+the next push republishes rather than validating against a stale environment.
+
+`validate_wheel.sh` pulls that image and falls back to a local `docker build`
+when the pull fails, so a developer without registry access still works.
+Rebuilding it on every release run meant refetching a 3.39 GB ROCm base layer
+each time, which exceeded the job timeout on runners that had not cached it.
+
 ## JIT-library producer
 
 `.github/workflows/jit-libs.yml` is the only CI job allowed to build the AITER

--- a/scripts/validate_wheel.sh
+++ b/scripts/validate_wheel.sh
@@ -21,8 +21,8 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-IMAGE_TAG="jax-aiter-validate:clean"
 DOCKERFILE="$REPO/docker/validation/Dockerfile.lite"
+IMAGE_TAG="$(bash "$REPO/ci/validation_image_id.sh")"
 
 VARIANT="lite"
 WHEEL=""
@@ -67,9 +67,20 @@ fi
 WHEEL_BASE="$(basename "$WHEEL")"
 echo "[validate_wheel] variant=$VARIANT wheel=$WHEEL_BASE"
 
-# Build the clean validation image (cached across runs).
-echo "[validate_wheel] docker build -> $IMAGE_TAG"
-docker build -t "$IMAGE_TAG" -f "$DOCKERFILE" "$REPO/docker/validation"
+# Prefer the published image. Rebuilding it here means fetching the base image
+# and reinstalling the JAX stack on every run, which is what made this step
+# exceed the job timeout on runners that had not cached the base layers.
+# validation-image.yml publishes one image per Dockerfile revision; fall back to
+# a local build so a developer without registry access, or a recipe edit that
+# has not been published yet, still works.
+if docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+  echo "[validate_wheel] image already local -> $IMAGE_TAG"
+elif docker pull "$IMAGE_TAG"; then
+  echo "[validate_wheel] pulled $IMAGE_TAG"
+else
+  echo "[validate_wheel] pull failed; building locally -> $IMAGE_TAG"
+  docker build -t "$IMAGE_TAG" -f "$DOCKERFILE" "$REPO/docker/validation"
+fi
 
 # Smoke command per variant.
 if [[ "$VARIANT" == "lite" ]]; then


### PR DESCRIPTION
## Problem

Three alpha2 release attempts died in "Validate default wheel in a clean TheRock container", and none of the failures was in our code or wheels. `validate_wheel.sh` ran `docker build` on every invocation, so each run refetched the base image and reinstalled the JAX stack. On a runner that had not cached those layers, that exceeded the 90-minute job timeout:

| Attempt | Layer progress | Rate |
|---|---|---|
| [31728845895](https://github.com/ROCm/jax-aiter/actions/runs/31728845895) first | 687 MB / 3.39 GB in 3616 s | ~0.19 MB/s |
| same run, retried | 974 MB / 3.39 GB in 1091 s | ~0.89 MB/s |

The stalling layer is `sha256:c521a8cf8aa4`, which belongs to the base image, not to anything we build.

## Why it was reliably cold

`jax-base-ubu24` and `jax-dev-ubu24` both carry a 3.39 GB ROCm layer, but with **different digests**:

| Layer | `jax-base` (validation) | `jax-dev` (every PR job) |
|---|---|---|
| ubuntu, 0.03 GB | `39a120c374bd` | `39a120c374bd` (shared) |
| ROCm, 3.39 GB | `c521a8cf8aa4` | `17601c520986` (different) |

`ci.yml` pulls `jax-dev` on every PR, so the `mi355` nodes keep those layers warm. Nothing else ever wanted `jax-base`, so the validation image was almost always a cold 3.39 GB fetch. That is also why the original publish-disabled run passed: it happened to land on a warm node.

## Changes

- **`validation-image.yml`** builds and pushes `ghcr.io/rocm/jax-aiter-validate:v<recipe-hash>`, with preflight skipping when the tag already exists, and a post-build import check of the JAX ROCm stack.
- **`ci/validation_image_id.sh`** is the single source of that reference, hashing `docker/validation/Dockerfile.lite` so a recipe edit produces a new tag rather than silently validating against a stale environment.
- **`validate_wheel.sh`** pulls the published image, falling back to a local build when the pull fails so developers without registry access still work.
- **`Dockerfile.lite`** now builds on `jax-dev-ubu24`, to share the layers the pool already caches.
- **`release-publish.yml`** gains `packages: read` and a `ghcr.io` login, so the pull succeeds rather than silently falling back to a build.

## Trade-off

The clean room is no longer strictly runtime-only: the dev base carries an LLVM layer we do not use. Nothing in the smoke tests compiles, and the guarantees that matter are unchanged — no AITER source, no MaxText, no build of this repo, and the wheel is pip-installed as a non-root user.

## Test plan

- [x] `bash -n` on both scripts; both new/changed workflows parse as YAML
- [x] Pull-or-build logic exercised in all three states with a stubbed docker: already-local (no pull, no build), pullable (pull only), unavailable (falls back to build)
- [x] Tag tracks the recipe and is stable: editing `Dockerfile.lite` changes the tag, reverting restores it
- [x] CPU CI scripts pass locally
- [ ] PR `cpu checks` and `gpu tests (1x MI355)`
- [ ] `validation-image.yml` publishes on merge to main
- [ ] Re-dispatch `release-publish.yml` with `publish=true`