### PR TITLE
fix(mha): bound and retry the attention-library download

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -215,6 +215,9 @@ jobs:
             | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Validate default wheel in a clean TheRock container
+        # Bound the step rather than letting a stall eat the whole job budget:
+        # a hung download once ran 87 minutes here and reported nothing useful.
+        timeout-minutes: 40
         run: |
           wheel="$(python3 - <<'PY'
           from pathlib import Path
@@ -224,6 +227,7 @@ jobs:
           bash scripts/validate_wheel.sh --variant lite "$wheel"
 
       - name: Validate full wheel in a clean TheRock container
+        timeout-minutes: 40
         run: |
           wheel="$(python3 - <<'PY'
           from pathlib import Path

--- a/jax_aiter/fetch_mha.py
+++ b/jax_aiter/fetch_mha.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -40,6 +41,12 @@ from .jit_assets import (
 DEFAULT_REPO = "ROCm/jax-aiter"
 MANIFEST_NAME = "manifest.json"
 
+# urlopen without a timeout blocks forever, so a connection that stalls midway
+# leaves the command hanging with no output and no recovery. Bound each socket
+# operation and retry, since these assets are fetched over the public internet.
+TIMEOUT_S = float(os.environ.get("JA_FETCH_TIMEOUT_S", "60"))
+RETRIES = max(1, int(os.environ.get("JA_FETCH_RETRIES", "4")))
+
 
 def _release_url(repo: str, tag: str, asset: str, base_url: str | None = None) -> str:
     if base_url:
@@ -48,16 +55,37 @@ def _release_url(repo: str, tag: str, asset: str, base_url: str | None = None) -
 
 
 def _download(url: str, dest: Path, *, quiet: bool = False) -> None:
+    asset = url.rsplit("/", 1)[-1]
     if not quiet:
-        print(f"  fetching {url.rsplit('/', 1)[-1]}", flush=True)
-    try:
-        with urllib.request.urlopen(url) as response, open(dest, "wb") as out:
-            shutil.copyfileobj(response, out, length=8 * 1024 * 1024)
-    except urllib.error.HTTPError as exc:
-        raise SystemExit(
-            f"error: could not download {url} ({exc.code} {exc.reason}).\n"
-            f"       Check that release '{DEFAULT_TAG}' exists and has this asset."
-        ) from exc
+        print(f"  fetching {asset}", flush=True)
+    for attempt in range(1, RETRIES + 1):
+        try:
+            with urllib.request.urlopen(url, timeout=TIMEOUT_S) as response, open(
+                dest, "wb"
+            ) as out:
+                shutil.copyfileobj(response, out, length=8 * 1024 * 1024)
+            return
+        except urllib.error.HTTPError as exc:
+            # A status code is a definite answer; retrying will not change it.
+            raise SystemExit(
+                f"error: could not download {url} ({exc.code} {exc.reason}).\n"
+                f"       Check that release '{DEFAULT_TAG}' exists and has this asset."
+            ) from exc
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            dest.unlink(missing_ok=True)
+            if attempt == RETRIES:
+                raise SystemExit(
+                    f"error: could not download {url} after {RETRIES} attempts "
+                    f"({TIMEOUT_S:g}s timeout each): {exc}\n"
+                    f"       Set JA_FETCH_TIMEOUT_S / JA_FETCH_RETRIES to adjust."
+                ) from exc
+            backoff = 2 ** (attempt - 1)
+            print(
+                f"  {asset}: attempt {attempt}/{RETRIES} failed ({exc}); "
+                f"retrying in {backoff}s",
+                flush=True,
+            )
+            time.sleep(backoff)
 
 
 def _sha256(path: Path) -> str:

--- a/tests/test_fetch_mha.py
+++ b/tests/test_fetch_mha.py
@@ -143,6 +143,46 @@ def test_fetch_rejects_corrupt_blob_without_partial_install(tmp_path, monkeypatc
     assert not (dest / "libmha_fwd.so").exists()
 
 
+def test_download_retries_transient_failures_then_succeeds(tmp_path, monkeypatch):
+    """A stalled connection must be retried, not waited on indefinitely."""
+    payload = b"recovered"
+    source = tmp_path / "asset.bin"
+    source.write_bytes(payload)
+    attempts = []
+    real_urlopen = fetch_mha.urllib.request.urlopen
+
+    def flaky(url, *args, **kwargs):
+        attempts.append(kwargs.get("timeout"))
+        if len(attempts) < 3:
+            raise TimeoutError("read timed out")
+        return real_urlopen(url, *args, **kwargs)
+
+    monkeypatch.setattr(fetch_mha.urllib.request, "urlopen", flaky)
+    monkeypatch.setattr(fetch_mha.time, "sleep", lambda _s: None)
+
+    dest = tmp_path / "out.bin"
+    fetch_mha._download(source.as_uri(), dest, quiet=True)
+
+    assert dest.read_bytes() == payload
+    assert len(attempts) == 3
+    # Every attempt must bound the socket, or a stall hangs forever.
+    assert all(t == fetch_mha.TIMEOUT_S for t in attempts)
+
+
+def test_download_gives_up_with_actionable_message(tmp_path, monkeypatch):
+    def always_stall(url, *args, **kwargs):
+        raise TimeoutError("read timed out")
+
+    monkeypatch.setattr(fetch_mha.urllib.request, "urlopen", always_stall)
+    monkeypatch.setattr(fetch_mha.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(fetch_mha, "RETRIES", 2)
+
+    dest = tmp_path / "out.bin"
+    with pytest.raises(SystemExit, match=r"(?s)after 2 attempts.*JA_FETCH_TIMEOUT_S"):
+        fetch_mha._download("https://example.invalid/asset.bin", dest, quiet=True)
+    assert not dest.exists()
+
+
 def test_failed_force_refresh_preserves_complete_active_generation(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Problem

Release run [31813433571](https://github.com/ROCm/jax-aiter/actions/runs/31813433571) timed out in wheel validation. The GPU work all passed:

```text
FP4 GEMM smoke PASS shape=(1024, 4096) dtype=bfloat16 time=11.10ms devices=[RocmDevice(id=0)]
MHA optional-library guard PASS
jax-aiter: fetching attention libraries into /tmp/ja-home/.cache/...
  fetching manifest.json
  3 libraries, 95 MB compressed (xz), built for gfx950
  fetching librmsnorm_fwd.so.xz          <- hung 85 minutes on a 4.5 MB asset
```

`urllib.request.urlopen(url)` was called with no `timeout`, and Python blocks indefinitely by default. There was no retry either. The manifest had already downloaded, so the connection stalled mid-transfer and nothing recovered it.

This matters more for users than for CI: install the default wheel, run `jax-aiter-fetch-mha` on a flaky network, and it hangs with no output and no recovery short of Ctrl-C.

## Fix

- Bound every socket operation: `JA_FETCH_TIMEOUT_S`, default 60s.
- Retry with exponential backoff: `JA_FETCH_RETRIES`, default 4, removing the partial file between attempts.
- Keep HTTP status codes fatal immediately — a 404 will not become a 200 on retry.
- The give-up message reports the attempt count and names both environment variables.
- Bound the two release validation steps at 40 minutes each, so a future stall fails fast rather than consuming the whole 90-minute job and reporting nothing useful.

## Test plan

- [x] `tests/test_fetch_mha.py` — 12 passed, including two new cases: transient failures retried then succeeding (asserting every attempt passes the timeout), and give-up producing an actionable message with no partial file left behind
- [ ] PR `cpu checks` and `gpu tests (1x MI355)`
- [ ] Re-dispatch `release-publish.yml` with `publish=true` after merge

## Status of the release

Everything ahead of this is now green and confirmed on a real runner: wheels build and audit, the prebuilt validation image is pulled rather than rebuilt, GPU device access works, FP4 GEMM runs on device, and the MHA guard behaves. This download stall is the last known blocker.